### PR TITLE
Manipulator ROS2CAN wrapper

### DIFF
--- a/src/can_wrapper/CMakeLists.txt
+++ b/src/can_wrapper/CMakeLists.txt
@@ -61,6 +61,8 @@ add_message_files(
   VescStatus.msg
   RoverControl.msg
   RoverStatus.msg
+  Stepper.msg
+  ManipulatorControl.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/src/can_wrapper/CMakeLists.txt
+++ b/src/can_wrapper/CMakeLists.txt
@@ -152,6 +152,7 @@ add_executable(${PROJECT_NAME}_node
  src/VescStatusHandler.cpp
  src/VescInterop.cpp
  src/StatusMessage.cpp
+ src/ManipulatorControl.cpp
 )
 
 ## Rename C++ executable without prefix

--- a/src/can_wrapper/include/can_wrapper/ManipulatorControl.hpp
+++ b/src/can_wrapper/include/can_wrapper/ManipulatorControl.hpp
@@ -1,0 +1,33 @@
+#ifndef ManipulatorControl_h_
+#define ManipulatorControl_h_
+
+#include <ros/ros.h>
+#include <string>
+#include <can_msgs/Frame.h>
+#include <array>
+#include <can_wrapper/VescInterop.hpp>
+#include "can_wrapper/RosCanConstants.hpp"
+#include "can_wrapper/ManipulatorControl.h"
+extern "C"
+{
+#include <libVescCan/VESC.h>
+}
+
+class ManipulatorControl
+{
+public:
+	ManipulatorControl(const ros::NodeHandle &nh);
+
+private:
+	void handleManipulatorCtl(const can_wrapper::ManipulatorControl::ConstPtr& manipulatroCtlMsg);
+
+	can_msgs::Frame encodeStepper(const can_wrapper::Stepper& stepper, const VESC_Id_t vescId);
+
+
+	ros::NodeHandle mNh;
+	ros::Publisher mRawCanPub;		 /**< ROS publisher for raw CAN messages. */
+	ros::Subscriber mManipulatorCtlSub; /**< ROS subscriber for motor velocity messages. */
+};
+
+
+#endif //ManipulatorControl_h_

--- a/src/can_wrapper/include/can_wrapper/RosCanConstants.hpp
+++ b/src/can_wrapper/include/can_wrapper/RosCanConstants.hpp
@@ -19,6 +19,7 @@ struct RosCanConstants
 		static const std::string can_stm_errors;		/**< Topic used for reporting STM32 errors. */
 		static const std::string can_stm_init;			/**< Topic used for initializing the STM32. */
 		static const std::string can_vesc_status;		/**< Topic with vesc motor status */
+		static const std::string can_manipulator_ctl;		/**< Topic used for manipulator 'manipulation' */
 	};
 
 	struct VescIds

--- a/src/can_wrapper/msg/ManipulatorControl.msg
+++ b/src/can_wrapper/msg/ManipulatorControl.msg
@@ -1,0 +1,3 @@
+Header header
+can_wrapper/Stepper[6] axes
+can_wrapper/Stepper gripper

--- a/src/can_wrapper/msg/Stepper.msg
+++ b/src/can_wrapper/msg/Stepper.msg
@@ -1,0 +1,2 @@
+uint8 commandId
+float32 setValue

--- a/src/can_wrapper/src/ManipulatorControl.cpp
+++ b/src/can_wrapper/src/ManipulatorControl.cpp
@@ -1,0 +1,40 @@
+#include "can_wrapper/ManipulatorControl.hpp"
+
+ManipulatorControl::ManipulatorControl(const ros::NodeHandle &nh): 
+	mNh(nh)
+{
+	mRawCanPub = mNh.advertise<can_msgs::Frame>(RosCanConstants::RosTopics::can_raw_TX, 256);
+	mManipulatorCtlSub = mNh.subscribe(RosCanConstants::RosTopics::can_manipulator_ctl, 256, &ManipulatorControl::handleManipulatorCtl, this);
+}
+void ManipulatorControl::handleManipulatorCtl(const can_wrapper::ManipulatorControl::ConstPtr &manipulatroCtlMsg)
+{
+	//7 since there are 6 axes + 1 gripper
+	std::array<can_msgs::Frame, 7> sendQueue;
+	auto sendQueueIter = sendQueue.begin();
+
+	*sendQueueIter++ = encodeStepper((*manipulatroCtlMsg).axes[0], RosCanConstants::VescIds::manipulator_axis_1);
+	*sendQueueIter++ = encodeStepper((*manipulatroCtlMsg).axes[1], RosCanConstants::VescIds::manipulator_axis_2);
+	*sendQueueIter++ = encodeStepper((*manipulatroCtlMsg).axes[2], RosCanConstants::VescIds::manipulator_axis_3);
+	*sendQueueIter++ = encodeStepper((*manipulatroCtlMsg).axes[3], RosCanConstants::VescIds::manipulator_axis_4);
+	*sendQueueIter++ = encodeStepper((*manipulatroCtlMsg).axes[4], RosCanConstants::VescIds::manipulator_axis_5);
+	*sendQueueIter++ = encodeStepper((*manipulatroCtlMsg).axes[5], RosCanConstants::VescIds::manipulator_axis_6);
+	*sendQueueIter++ = encodeStepper((*manipulatroCtlMsg).gripper, RosCanConstants::VescIds::manipulator_gripper);
+
+	for(auto iter = sendQueue.begin(); iter < sendQueue.end(); iter++)
+		mRawCanPub.publish(*iter);
+}
+
+can_msgs::Frame ManipulatorControl::encodeStepper(const can_wrapper::Stepper &stepper, const VESC_Id_t vescId)
+{
+	VESC_CommandFrame vesc_cf;
+	VESC_ZeroMemory(&vesc_cf, sizeof(vesc_cf));
+	VESC_RawFrame vesc_rf;
+	VESC_ZeroMemory(&vesc_rf, sizeof(vesc_rf));
+
+	vesc_cf.vescID = vescId;
+	vesc_cf.command = stepper.commandId;
+	vesc_cf.commandData = stepper.setValue;
+
+	VESC_convertCmdToRaw(&vesc_rf, &vesc_cf);
+	return VescInterop::vescToRos(vesc_rf);
+}

--- a/src/can_wrapper/src/RosCanConstants.cpp
+++ b/src/can_wrapper/src/RosCanConstants.cpp
@@ -8,6 +8,7 @@ const std::string RosCanConstants::RosTopics::can_get_motor_current = "/CAN/RX/r
 const std::string RosCanConstants::RosTopics::can_stm_errors = "/CAN/RX/stm_errors";
 const std::string RosCanConstants::RosTopics::can_stm_init = "/CAN/TX/stm_init";
 const std::string RosCanConstants::RosTopics::can_vesc_status = "/CAN/RX/vesc_status";
+const std::string RosCanConstants::RosTopics::can_manipulator_ctl = "/CAN/TX/manipulator_ctl";
 
 const uint8_t RosCanConstants::VescIds::ros_can_host = 0x20; /**< ID for the computer that interconnects ROS and CAN BUS. */
 

--- a/src/can_wrapper/src/can_wrapper.cpp
+++ b/src/can_wrapper/src/can_wrapper.cpp
@@ -9,6 +9,7 @@
 #include "can_wrapper/VescStatusHandler.hpp"
 #include "can_wrapper/RoverControl.h"
 #include "can_wrapper/StatusMessage.hpp"
+#include "can_wrapper/ManipulatorControl.hpp"
 
 #include <ros/service.h>
 #include <std_srvs/SetBool.h>
@@ -42,6 +43,7 @@ int main(int argc, char *argv[])
 	MotorControl motorControl(n);
 	VescStatusHandler mVescStatusHandler(n);
 	StatusMessage mStatusMessage(n, true);
+	ManipulatorControl mManipulatorCtl(n);
 
 	CanNodeMode canNodeMode = CanNodeMode::Created;
 	ros::Rate rate(100);


### PR DESCRIPTION
Converts ROS messages to CAN frames. Simple as that. 
Merging to `dev/StatusMessageToCan` cause it is based on it (`RosCanConstants` with manipulator axes).