### PR TITLE
Probe CAN2ROS

### DIFF
--- a/src/can_wrapper/CMakeLists.txt
+++ b/src/can_wrapper/CMakeLists.txt
@@ -154,6 +154,7 @@ add_executable(${PROJECT_NAME}_node
  src/VescInterop.cpp
  src/StatusMessage.cpp
  src/ManipulatorControl.cpp
+ src/ProbeStatusForwarder.cpp
 )
 
 ## Rename C++ executable without prefix

--- a/src/can_wrapper/CMakeLists.txt
+++ b/src/can_wrapper/CMakeLists.txt
@@ -63,6 +63,7 @@ add_message_files(
   RoverStatus.msg
   Stepper.msg
   ManipulatorControl.msg
+  ProbeStatus.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/src/can_wrapper/include/can_wrapper/ProbeStatusForwarder.hpp
+++ b/src/can_wrapper/include/can_wrapper/ProbeStatusForwarder.hpp
@@ -1,0 +1,49 @@
+#ifndef ProbeStatusForwarder_h_
+#define ProbeStatusForwarder_h_
+
+#include <ros/ros.h>
+#include <boost/shared_ptr.hpp>
+#include <can_wrapper/ProbeStatus.h>
+#include <can_wrapper/RosCanConstants.hpp>
+#include <can_wrapper/VescInterop.hpp>
+#include <can_msgs/Frame.h>
+extern "C"
+{
+#include <libVescCan/VESC.h>
+}
+
+class ProbeStatusForwarder
+{
+public:
+	ProbeStatusForwarder(ros::NodeHandle& nh);
+
+private:
+	void probeStatusGrabber(const can_msgs::Frame::ConstPtr &frame);
+	void statusPublisher();
+
+	void newStatus8(VESC_Status_8& status8);
+	void newStatus9(VESC_Status_9& status9);
+
+	void warnRotten(int statusNum);
+	void infoNotRotten();
+
+
+	const uint8_t ROTTEN_THRESHOLD = 10;
+
+	ros::NodeHandle mNh;
+
+	bool mRottenNoted = false;
+
+	VESC_Status_8 mStatus8;
+	bool mStatus8Fresh = false;
+	uint8_t mStatus8Staleness = 0;
+
+	VESC_Status_9 mStatus9;
+	bool mStatus9Fresh = false;
+	uint8_t mStatus9Staleness = 0;
+
+	ros::Subscriber mProbeStatusGrabber;
+	ros::Publisher mProbeStatusPublisher;	
+};
+
+#endif //ProbeStatusForwarder_h_

--- a/src/can_wrapper/include/can_wrapper/RosCanConstants.hpp
+++ b/src/can_wrapper/include/can_wrapper/RosCanConstants.hpp
@@ -20,6 +20,7 @@ struct RosCanConstants
 		static const std::string can_stm_init;			/**< Topic used for initializing the STM32. */
 		static const std::string can_vesc_status;		/**< Topic with vesc motor status */
 		static const std::string can_manipulator_ctl;		/**< Topic used for manipulator 'manipulation' */
+		static const std::string can_probe_status;		/**< Topic with probe status */
 	};
 
 	struct VescIds

--- a/src/can_wrapper/msg/ProbeStatus.msg
+++ b/src/can_wrapper/msg/ProbeStatus.msg
@@ -1,0 +1,10 @@
+Header header
+float32 weightA
+float32 distance
+float32 humidity
+bool vibrations
+float32 weightB
+float32 potassium
+float32 nitrogen
+float32 phosphorus
+float32 ph

--- a/src/can_wrapper/src/ProbeStatusForwarder.cpp
+++ b/src/can_wrapper/src/ProbeStatusForwarder.cpp
@@ -1,0 +1,110 @@
+#include <can_wrapper/ProbeStatusForwarder.hpp>
+
+ProbeStatusForwarder::ProbeStatusForwarder(ros::NodeHandle &nh):
+    mNh(nh)
+{
+    mProbeStatusGrabber = nh.subscribe<can_msgs::Frame>(RosCanConstants::RosTopics::can_raw_RX,1024,&ProbeStatusForwarder::probeStatusGrabber,this);
+	mProbeStatusPublisher = nh.advertise<can_wrapper::ProbeStatus>(RosCanConstants::RosTopics::can_probe_status,256);
+}
+
+void ProbeStatusForwarder::probeStatusGrabber(const can_msgs::Frame::ConstPtr &frame)
+{
+    auto rf = VescInterop::rosToVesc(*frame);
+
+    switch(rf.command)
+    {
+        case VESC_COMMAND_STATUS_8:
+            VESC_Status_8 status8;
+            VESC_ZeroMemory(&status8, sizeof(status8));
+            VESC_convertRawToStatus8(&status8, &rf);
+			newStatus8(status8);
+        	break;
+        case VESC_COMMAND_STATUS_9:
+            VESC_Status_9 status9;
+            VESC_ZeroMemory(&status9, sizeof(status9));
+            VESC_convertRawToStatus9(&status9, &rf);
+			newStatus9(status9);
+        	break;
+		default:
+			return;
+    };
+
+	statusPublisher();
+}
+
+void ProbeStatusForwarder::newStatus8(VESC_Status_8 &status8)
+{
+	mStatus8 = status8;
+	mStatus8Fresh = true;
+	mStatus8Staleness = 0;
+
+	if(mStatus9Staleness < UINT8_MAX)
+		mStatus9Staleness++;
+}
+
+void ProbeStatusForwarder::newStatus9(VESC_Status_9 & status9)
+{
+	mStatus9 = status9;
+	mStatus9Fresh = true;
+	mStatus9Staleness = 0;
+
+	if(mStatus8Staleness < UINT8_MAX)
+		mStatus8Staleness++;
+}
+
+void ProbeStatusForwarder::warnRotten(int statusNum)
+{
+	if(!mRottenNoted)
+	{
+		mRottenNoted = true;
+		ROS_WARN("[ProbeStatusForwarder]: Status %i was not updated recently while other was (Threshold (%i) reached). Publishing of ProbeStatus will resume with last value!", statusNum, ROTTEN_THRESHOLD);
+	}
+}
+
+void ProbeStatusForwarder::infoNotRotten()
+{
+	if(mRottenNoted)
+	{
+		mRottenNoted = false;
+		ROS_INFO("[ProbeStatusForwarder]: All statuses were updated recently.");
+	}
+}
+
+void ProbeStatusForwarder::statusPublisher()
+{	
+	if(mStatus8Staleness > ROTTEN_THRESHOLD)
+	{
+		warnRotten(8);
+	}
+	else if(mStatus9Staleness > ROTTEN_THRESHOLD)
+	{
+		warnRotten(9);
+	}
+	else if(!mStatus8Fresh || !mStatus9Fresh)
+		return;
+
+	can_wrapper::ProbeStatus status;
+
+	status.weightA = mStatus8.weightA;
+	status.distance = mStatus8.distance;
+	status.humidity = mStatus8.humidity;
+	status.vibrations = mStatus8.vibrations;
+	status.weightB = mStatus8.weightB;
+
+	status.potassium = mStatus9.potassium;
+	status.nitrogen = mStatus9.nitrogen;
+	status.phosphorus = mStatus9.phosphorus;
+	status.ph = mStatus9.ph;
+
+	status.header.stamp = ros::Time::now();
+
+	mProbeStatusPublisher.publish(status);
+
+	if(mStatus8Fresh && mStatus9Fresh)
+	{
+		infoNotRotten();
+		mStatus8Fresh = false;
+		mStatus9Fresh = false;
+	}
+
+}

--- a/src/can_wrapper/src/RosCanConstants.cpp
+++ b/src/can_wrapper/src/RosCanConstants.cpp
@@ -9,6 +9,7 @@ const std::string RosCanConstants::RosTopics::can_stm_errors = "/CAN/RX/stm_erro
 const std::string RosCanConstants::RosTopics::can_stm_init = "/CAN/TX/stm_init";
 const std::string RosCanConstants::RosTopics::can_vesc_status = "/CAN/RX/vesc_status";
 const std::string RosCanConstants::RosTopics::can_manipulator_ctl = "/CAN/TX/manipulator_ctl";
+const std::string RosCanConstants::RosTopics::can_probe_status = "/CAN/RX/probe_status";
 
 const uint8_t RosCanConstants::VescIds::ros_can_host = 0x20; /**< ID for the computer that interconnects ROS and CAN BUS. */
 

--- a/src/can_wrapper/src/can_wrapper.cpp
+++ b/src/can_wrapper/src/can_wrapper.cpp
@@ -10,6 +10,7 @@
 #include "can_wrapper/RoverControl.h"
 #include "can_wrapper/StatusMessage.hpp"
 #include "can_wrapper/ManipulatorControl.hpp"
+#include "can_wrapper/ProbeStatusForwarder.hpp"
 
 #include <ros/service.h>
 #include <std_srvs/SetBool.h>
@@ -44,6 +45,7 @@ int main(int argc, char *argv[])
 	VescStatusHandler mVescStatusHandler(n);
 	StatusMessage mStatusMessage(n, true);
 	ManipulatorControl mManipulatorCtl(n);
+	ProbeStatusForwarder mProbeStatusForwarder(n);
 
 	CanNodeMode canNodeMode = CanNodeMode::Created;
 	ros::Rate rate(100);


### PR DESCRIPTION
Forwarder for status 8 & 9 sent from probe.
Status 8 & 9 are packed in single ProbeStatus message published on (ROS Topic) "/CAN/RX/probe_status".