### PR TITLE
 mqtt-bridge + can_wrapper: Update rover control msg, add sampler control

### DIFF
--- a/src/can_wrapper/msg/RoverControl.msg
+++ b/src/can_wrapper/msg/RoverControl.msg
@@ -1,3 +1,5 @@
 Header header
-float64 XVelAxis
-float64 ZRotAxis
+float64 Vel
+float64 XAxis
+float64 YAxis
+uint8 Mode

--- a/src/mqtt_bridge/CMakeLists.txt
+++ b/src/mqtt_bridge/CMakeLists.txt
@@ -55,6 +55,7 @@ find_package(PahoMqttCpp REQUIRED)
 add_message_files(
   FILES
   ManipulatorMessage.msg
+  SamplerMessage.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/src/mqtt_bridge/include/mqtt_bridge/ROSTopicHandler.hpp
+++ b/src/mqtt_bridge/include/mqtt_bridge/ROSTopicHandler.hpp
@@ -8,6 +8,7 @@
 #include "can_wrapper/RoverControl.h"
 #include "can_wrapper/RoverStatus.h"
 #include "mqtt_bridge/ManipulatorMessage.h"
+#include "mqtt_bridge/SamplerMessage.h"
 #define RAPIDJSON_HAS_STDSTRING 1
 #include "rapidjson/document.h"
 
@@ -25,6 +26,7 @@ public:
   void publishMessage_Wheels(can_wrapper::Wheels message);
   void publishMessage_RoverControl(can_wrapper::RoverControl message);
   void publishMessage_ManipulatorControl(mqtt_bridge::ManipulatorMessage message);
+  void publishMessage_SamplerControl(mqtt_bridge::SamplerMessage message);
   void publishMessage_RoverStatus(can_wrapper::RoverStatus message);
 
 private:
@@ -61,6 +63,7 @@ private:
   ros::Publisher mPub_Wheels;
   ros::Publisher mPub_RoverControl;
   ros::Publisher mPub_ManipulatorControl;
+  ros::Publisher mPub_SamplerControl;
   ros::Publisher mPub_RoverStatus;
 };
 

--- a/src/mqtt_bridge/msg/SamplerMessage.msg
+++ b/src/mqtt_bridge/msg/SamplerMessage.msg
@@ -1,0 +1,5 @@
+Header header
+uint8 DrillCommand
+uint8 PlatformCommand
+uint8 DrillState
+bool isContainerExtended

--- a/src/mqtt_bridge/src/ROSTopicHandler.cpp
+++ b/src/mqtt_bridge/src/ROSTopicHandler.cpp
@@ -21,6 +21,7 @@ ROSTopicHandler::ROSTopicHandler(std::shared_ptr<mqtt::async_client> mqttClient,
 	mPub_Wheels = n.advertise<can_wrapper::Wheels>("/CAN/TX/set_motor_vel", 1000);
 	mPub_RoverControl = n.advertise<can_wrapper::RoverControl>("/MQTT/RoverControl", 1000);
 	mPub_ManipulatorControl = n.advertise<mqtt_bridge::ManipulatorMessage>("/manipulator_joints", 1000);
+	mPub_SamplerControl = n.advertise<mqtt_bridge::SamplerMessage>("/MQTT/SamplerControl", 1000);
 	mPub_RoverStatus = n.advertise<can_wrapper::RoverStatus>("/MQTT/RoverStatus", 1000);
 }
 
@@ -323,6 +324,14 @@ void ROSTopicHandler::publishMessage_ManipulatorControl(mqtt_bridge::Manipulator
 {
 	mPub_ManipulatorControl.publish(message);
 	ROS_DEBUG("I published (ROS): a message (ManipulatorControl)");
+}
+
+// ##### SamplerControl ######
+
+void ROSTopicHandler::publishMessage_SamplerControl(mqtt_bridge::SamplerMessage message)
+{
+	mPub_SamplerControl.publish(message);
+	ROS_DEBUG("I published (ROS): a message (SamplerControl)");
 }
 
 // ##### RoverStatus ######

--- a/src/mqtt_bridge/src/mqtt_bridge_node.cpp
+++ b/src/mqtt_bridge/src/mqtt_bridge_node.cpp
@@ -86,7 +86,7 @@ void processMqttRoverControlMessage(const char *payloadMsg, std::shared_ptr<ROST
 			msg.Vel = d["Vel"].GetDouble();
 			msg.XAxis = d["XAxis"].GetDouble();
 			msg.YAxis = d["YAxis"].GetDouble();
-			msg.Mode = d["Mode"].GetDouble();
+			msg.Mode = d["Mode"].GetUint();
 
 			msg.header.stamp = unixMillisecondsToROSTimestamp(d["Timestamp"].GetUint64());
 

--- a/src/mqtt_bridge/src/mqtt_bridge_node.cpp
+++ b/src/mqtt_bridge/src/mqtt_bridge_node.cpp
@@ -132,6 +132,38 @@ void processMqttManipulatorControlMessage(const char *payloadMsg, std::shared_pt
 		}
 	}
 }
+
+void processMqttSamplerControlMessage(const char *payloadMsg, std::shared_ptr<ROSTopicHandler> rth)
+{
+	rapidjson::Document d;
+	rapidjson::ParseResult ok = d.Parse(payloadMsg);
+
+	if (!ok)
+	{
+		ROS_WARN_STREAM("JSON parse error: " << rapidjson::GetParseError_En(ok.Code()) << " (" << ok.Offset() << "), discarding MQTT message.");
+	}
+	else
+	{
+		try
+		{
+			mqtt_bridge::SamplerMessage msg;
+
+			msg.DrillCommand = d["DrillCommand"].GetUint();
+			msg.PlatformCommand = d["PlatformCommand"].GetUint();
+			msg.DrillState = d["DrillState"].GetUint();
+			msg.isContainerExtended = d["isContainerExtended"].GetBool();
+
+			msg.header.stamp = unixMillisecondsToROSTimestamp(d["Timestamp"].GetUint64());
+
+			rth->publishMessage_SamplerControl(msg);
+		}
+		catch (JsonAssertException e)
+		{
+			ROS_WARN("JSON assert exception, discarding MQTT message.");
+		}
+	}
+}
+
 //TODO
 void processMqttRoverStatusMessage(const char *payloadMsg, std::shared_ptr<ROSTopicHandler> rth)
 {
@@ -184,8 +216,8 @@ int main(int argc, char *argv[])
 	const std::chrono::seconds RECONNECT_MAX_RETRY_INTERVAL{16};
 	const bool CLEAN_START = false;
 
-	auto SUBSCRIBED_TOPICS_NAMES = mqtt::string_collection::create({"RappTORS/Wheels", "RappTORS/RoverControl", "RappTORS/ManipulatorControl", "RappTORS/RoverStatus"});
-	const std::vector<int> SUBSCRIBED_TOPICS_QOS{0, 0, 0, 0};
+	auto SUBSCRIBED_TOPICS_NAMES = mqtt::string_collection::create({"RappTORS/Wheels", "RappTORS/RoverControl", "RappTORS/ManipulatorControl", "RappTORS/RoverStatus", "RappTORS/SamplerControl"});
+	const std::vector<int> SUBSCRIBED_TOPICS_QOS{0, 0, 0, 0, 0};
 
 
 	std::shared_ptr<mqtt::async_client> cli = std::make_shared<mqtt::async_client>(SERVER_ADDRESS, CLIENT_ID,
@@ -219,7 +251,9 @@ int main(int argc, char *argv[])
 			processMqttManipulatorControlMessage(mqtt_msg->get_payload_str().c_str(), rth);
 		} else if (messageTopic == "RappTORS/RoverStatus") {
 			processMqttRoverStatusMessage(mqtt_msg->get_payload_str().c_str(), rth);
-		} else {
+		} else if (messageTopic == "RappTORS/SamplerControl") {
+			processMqttSamplerControlMessage(mqtt_msg->get_payload_str().c_str(), rth);
+		}  else {
 			ROS_WARN_STREAM("Unknown MQTT topic: " << messageTopic << ", discarding MQTT message.");
 		} });
 

--- a/src/mqtt_bridge/src/mqtt_bridge_node.cpp
+++ b/src/mqtt_bridge/src/mqtt_bridge_node.cpp
@@ -83,8 +83,10 @@ void processMqttRoverControlMessage(const char *payloadMsg, std::shared_ptr<ROST
 		{
 			can_wrapper::RoverControl msg;
 
-			msg.XVelAxis = d["XVelAxis"].GetDouble();
-			msg.ZRotAxis = d["ZRotAxis"].GetDouble();
+			msg.Vel = d["Vel"].GetDouble();
+			msg.XAxis = d["XAxis"].GetDouble();
+			msg.YAxis = d["YAxis"].GetDouble();
+			msg.Mode = d["Mode"].GetDouble();
 
 			msg.header.stamp = unixMillisecondsToROSTimestamp(d["Timestamp"].GetUint64());
 


### PR DESCRIPTION
Same as #21 but this time I (hopefully) won't missclick