### PR TITLE
Change default image for master to avoid confusion

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       dockerfile: ./.devcontainer/Dockerfile
       args:
         SSH_PORT: 2122
-    image: wisniax/ros-core:latest
+    image: wisniax/ros-core:nightly
     stdin_open: true
     container_name: ros-core
     hostname: ros-core


### PR DESCRIPTION
From lastest <- latest release
to nightly <- latest commit to master


_I 100% did not waste like 40 mins figuring why the heck master branch does not work on the rover_ `(it did - just image was wrong)`