### PR TITLE
Alignment calibration functionality for wheels and axes of manipulator

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -11,7 +11,8 @@
                 "${workspaceFolder}/src/rex_interfaces/include/**",
                 "${workspaceFolder}/src/can_bridge/include/**",
                 "${workspaceFolder}/src/libVescCan/include/**",
-                "${workspaceFolder}/src/can_bridge/libVescCan/include/**"
+                "${workspaceFolder}/src/can_bridge/libVescCan/include/**",
+                "${workspaceFolder}/src/calibration_manager/include/**"
             ],
             "name": "ROS",
             "intelliSenseMode": "gcc-x64",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,18 +44,12 @@ services:
     container_name: mosquitto
     network_mode: host
     volumes:
-      - ./.devcontainer/mosquitto.conf:/mosquitto/config/mosquitto.conf
+      - ./.devcontainer/mosquitto.conf:/mosquitto/config/mosquitto.conf:Z
       # read-only bind mounts make compose fail when the source path doesn't exist - and this is our intention here
-      - type: bind
-        source: ./.devcontainer/mosquitto_passwd
-        target: /mosquitto/mosquitto_passwd
-        read_only: true
-      - ./.mosquitto/data:/mosquitto/data
-      - ./.mosquitto/log:/mosquitto/log
-      - type: bind
-        source: ./.devcontainer/mqtt-server-certs
-        target: /mosquitto/certs
-        read_only: true
+      - ./.devcontainer/mosquitto_passwd:/mosquitto/mosquitto_passwd:ro,Z
+      - ./.mosquitto/data:/mosquitto/data:Z
+      - ./.mosquitto/log:/mosquitto/log:Z
+      - ./.devcontainer/mqtt-server-certs:/mosquitto/certs:ro,Z
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "mosquitto_sub", "-h", "localhost", "-p", "8883", "-t", "$$SYS/#", "--cafile", "/mosquitto/certs/ca.crt", "-u", "${MQTT_USERNAME:-raptors}", "-P", "${MQTT_PASSWORD:-changeme}", "-C", "1", "-i", "healthcheck", "-W", "3"]

--- a/src/calibration_manager/CMakeLists.txt
+++ b/src/calibration_manager/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.8)
+project(calibration_manager)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(ament_index_cpp REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(libVescCan REQUIRED)
+find_package(rex_interfaces REQUIRED)
+find_package(ros_constants REQUIRED)
+
+add_executable(calibration_manager_node
+  src/calibration_manager.cpp
+  src/CalibrateAxis.cpp
+)
+
+target_include_directories(calibration_manager_node PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
+
+target_link_libraries(calibration_manager_node PUBLIC
+  ament_index_cpp::ament_index_cpp
+  ${cpp_typesupport_target}
+  ${rex_interfaces_TARGETS}
+  rclcpp::rclcpp
+  ros_constants::ros_constants
+  libVescCan::libVescCan
+)
+target_compile_features(calibration_manager_node PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+
+install(TARGETS calibration_manager_node
+  DESTINATION lib/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/src/calibration_manager/CMakeLists.txt
+++ b/src/calibration_manager/CMakeLists.txt
@@ -12,28 +12,44 @@ find_package(rclcpp REQUIRED)
 find_package(libVescCan REQUIRED)
 find_package(rex_interfaces REQUIRED)
 find_package(ros_constants REQUIRED)
+find_package(rclcpp_components REQUIRED)
 
-add_executable(calibration_manager_node
+add_library(${PROJECT_NAME}_component SHARED
   src/calibration_manager.cpp
   src/CalibrateAxis.cpp
 )
 
-target_include_directories(calibration_manager_node PUBLIC
+target_include_directories(${PROJECT_NAME}_component PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include/${PROJECT_NAME}>)
 
-target_link_libraries(calibration_manager_node PUBLIC
+target_link_libraries(${PROJECT_NAME}_component PUBLIC
   ament_index_cpp::ament_index_cpp
   ${cpp_typesupport_target}
   ${rex_interfaces_TARGETS}
+  ${rclcpp_components_TARGETS}
   rclcpp::rclcpp
   ros_constants::ros_constants
   libVescCan::libVescCan
 )
-target_compile_features(calibration_manager_node PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
+target_compile_features(${PROJECT_NAME}_component PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
 
-install(TARGETS calibration_manager_node
-  DESTINATION lib/${PROJECT_NAME})
+rclcpp_components_register_node(
+  ${PROJECT_NAME}_component
+  PLUGIN "CalibrateAxis"
+  EXECUTABLE calibrate_axis
+)
+
+install(TARGETS ${PROJECT_NAME}_component
+  EXPORT export_${PROJECT_NAME}_component
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib
+)
+
+install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/src/calibration_manager/LICENSE
+++ b/src/calibration_manager/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/calibration_manager/README.md
+++ b/src/calibration_manager/README.md
@@ -1,0 +1,114 @@
+# Motor calibration
+
+ROS node which allows for Cubemars motor calibration.
+
+[[Cubemars manual](https://www.cubemars.com/images/file/20240611/1718085712815162.pdf)] [[libVescCan](https://github.com/AlvaroBajceps/libVescCan/)]
+
+## Table of Contents
+- [Frame Format](#frame-format)
+- [Modes](#modes)
+    - [SetVelocity](#setvelocity)
+    - [SetPos](#setpos)
+    - [Hold](#hold)
+    - [Nothing](#nothing)
+- [Parameters](#parameters)
+- [Actions](#actions)
+    - [STOP](#action_type_stop-0)
+    - [RETURN_TO_ORIGIN](#action_type_return_to_origin-1)
+    - [CONFIRM](#action_type_confirm-2)
+    - [CANCEL](#action_type_cancel-3)
+    - [OFFSET](#action_type_offset-4)
+    - [SET_VELOCITY](#action_type_set_velocity-5)
+- [FAQ](#faq)
+
+
+## Frame format
+
+```
+# action_type enum
+uint8 ACTION_TYPE_STOP = 0
+uint8 ACTION_TYPE_RETURN_TO_ORIGIN = 1
+uint8 ACTION_TYPE_CONFIRM = 2
+uint8 ACTION_TYPE_CANCEL = 3
+uint8 ACTION_TYPE_OFFSET = 4
+uint8 ACTION_TYPE_SET_VELOCITY = 5
+
+std_msgs/Header header
+uint8 vesc_id
+uint8 action_type
+float32 value
+```
+
+## Modes
+
+The calibration node is in one four modes at all times.
+
+### SetVelocity
+Continously sends VESC `SET_RPM` frames over CAN.<br />
+A timeout is set - if there is `SET_VELOCITY` frame from the app for a specified amount of time, mode is changed to `Hold`<br />
+During this mode, only `CANCEL`, `STOP` and `SET_VELOCITY` frames are accepted.
+
+### SetPos
+Continously sends VESC `SET_POS` frames over CAN.
+Depending on the condition set, stops when:
+
+1. ERPM = 0 (from the motor's VescStatus)
+2. Position of the motor is almost at the target position (see `calibration.stop_tolerance`)
+3. Both
+4. Either
+
+It then switches to `Hold`.<br />
+During this mode, only `CANCEL`, `STOP` frames are accepted.
+
+### Hold
+Actively holds the motor's position to prevent any drift (using VESC `SET_POS` frames).
+
+
+### Nothing
+Idle mode, does nothing. No frames are sent over CAN.
+
+## Parameters
+
+Parameter                            | Type  | Unit | Description
+-------------------------------------|-------|------|-------------------------------------------------------------------------------------------
+`calibration.max_speed`              | float | ERPM | Max speed for SetVelocity mode.[0]
+`calibration.max_offset_shift`       | float | deg  | Max value for a single `Offset` command.[0]
+`calibration.max_velocity_shift`     | float | deg  | Max rotation away from origin for SetPos mode[1].
+`calibration.outdated_duration_s`    | float | s    | Time after which a `VescStatus` frame is considered outdated.
+`calibration.speed_timeout_ms`       | float | ms   | Timeout for SetVelocity. If no frame comes from the app in this time, the motor is stopped
+`calibration.message_send_period_ms` | float | ms   | Period at which to send VESC frames.
+`calibration.stop_condition`         | int   | -    | Which variant of the SetPos stop condition to use
+`calibration.stop_tolerance`         | int   | deg  | Position tolerance to decide when SetPos can be stopped
+`calibration.log_setpos_diff`        | int   | 0/1  | Whether to log current_position<->target_position during SetPos
+`calibration.use_schedule_hold`      | int   | 0/1  | Whether to delay holding until next received VESC status (to prevent jerk)
+
+[0] - values outside of range are clamped<br>
+[1] - to rotate more, set origin and try again
+
+## Actions
+
+Each frame has to have `vesc_id` set to an ID of a motor.
+
+### ACTION_TYPE_STOP [0]
+Stops the motor and switches to `Hold`.
+
+### ACTION_TYPE_RETURN_TO_ORIGIN [1]
+Moves the motor to its origin position using `SetPos` mode.
+
+### ACTION_TYPE_CONFIRM [2]
+Sets the origin of a motor at its current position.
+
+### ACTION_TYPE_CANCEL [3]
+Stops the motor, doesn't hold its position. Use this to abort calibration.
+
+### ACTION_TYPE_OFFSET [4]
+Rotates the motor by `value` degrees. Cannot rotate more than specifiec in `calibration.max_offset_shift`.
+
+### ACTION_TYPE_SET_VELOCITY [5]
+Sets the speed at which to rotate the motor.
+If `0.0` is set, the motor stops and switches to `Hold`.
+
+## FAQ
+
+- What happens if motor 2 starts being calibrated when motor 1 is still being calibrated?
+    - Only one motor can be calibrated at a time. In this case, motor 1 would be stopped (without hold) and calibration of motor 2 would continue as normal

--- a/src/calibration_manager/README.md
+++ b/src/calibration_manager/README.md
@@ -1,6 +1,7 @@
 # Motor calibration
 
-ROS node which allows for Cubemars motor calibration.
+ROS node which allows for Cubemars motor calibration.<br />
+Calibration can be performed in app E-STOP mode. The black mushroom cannot be pushed in.
 
 [[Cubemars manual](https://www.cubemars.com/images/file/20240611/1718085712815162.pdf)] [[libVescCan](https://github.com/AlvaroBajceps/libVescCan/)]
 
@@ -49,15 +50,8 @@ A timeout is set - if there is `SET_VELOCITY` frame from the app for a specified
 During this mode, only `CANCEL`, `STOP` and `SET_VELOCITY` frames are accepted.
 
 ### SetPos
-Continously sends VESC `SET_POS` frames over CAN.
-Depending on the condition set, stops when:
-
-1. ERPM = 0 (from the motor's VescStatus)
-2. Position of the motor is almost at the target position (see `stop_tolerance` param)
-3. Both
-4. Either
-
-It then switches to `Hold`.<br />
+Continously sends VESC `SET_POS` frames over CAN.<br />
+Stops when ERPM = 0 and position is almost at target (see `stop_tolerance` param), it then switches to `Hold`.<br />
 During this mode, only `CANCEL`, `STOP` frames are accepted.
 
 ### Hold

--- a/src/calibration_manager/README.md
+++ b/src/calibration_manager/README.md
@@ -71,10 +71,8 @@ Parameter                            | Type  | Unit | Description
 `outdated_duration_s`    | float | s    | Time after which a `VescStatus` frame is considered outdated.
 `speed_timeout_ms`       | float | ms   | Timeout for SetVelocity. If no frame comes from the app in this time, the motor is stopped
 `message_send_period_ms` | float | ms   | Period at which to send VESC frames.
-`stop_condition`         | int   | -    | Which variant of the SetPos stop condition to use
 `stop_tolerance`         | int   | deg  | Position tolerance to decide when SetPos can be stopped
 `log_setpos_diff`        | int   | 0/1  | Whether to log current_position<->target_position during SetPos
-`use_schedule_hold`      | int   | 0/1  | Whether to delay holding until next received VESC status (to prevent jerk), see [FAQ](#faq)
 
 [0] - values outside of range are clamped<br />
 [1] - to rotate more, set origin and try again
@@ -114,5 +112,3 @@ If you need to rotate more, set origin and repeat.
 
 - What happens if motor 2 starts being calibrated when motor 1 is still being calibrated?
     - Only one motor can be calibrated at a time. In this case, motor 1 would be stopped (without hold) and calibration of motor 2 would continue as normal
-- What is hold scheduling?
-    - Normally, when the motor is rotated by velocity and then stopped, it holds at the last known position. It may cause the motor to jerk backwards before stopping. When hold scheduling is enabled, the motor is first stopped, and held only when a new position is received.

--- a/src/calibration_manager/README.md
+++ b/src/calibration_manager/README.md
@@ -53,7 +53,7 @@ Continously sends VESC `SET_POS` frames over CAN.
 Depending on the condition set, stops when:
 
 1. ERPM = 0 (from the motor's VescStatus)
-2. Position of the motor is almost at the target position (see `calibration.stop_tolerance`)
+2. Position of the motor is almost at the target position (see `stop_tolerance` param)
 3. Both
 4. Either
 
@@ -71,19 +71,24 @@ Idle mode, does nothing. No frames are sent over CAN.
 
 Parameter                            | Type  | Unit | Description
 -------------------------------------|-------|------|-------------------------------------------------------------------------------------------
-`calibration.max_speed`              | float | ERPM | Max speed for SetVelocity mode.[0]
-`calibration.max_offset_shift`       | float | deg  | Max value for a single `Offset` command.[0]
-`calibration.max_velocity_shift`     | float | deg  | Max rotation away from origin for SetPos mode[1].
-`calibration.outdated_duration_s`    | float | s    | Time after which a `VescStatus` frame is considered outdated.
-`calibration.speed_timeout_ms`       | float | ms   | Timeout for SetVelocity. If no frame comes from the app in this time, the motor is stopped
-`calibration.message_send_period_ms` | float | ms   | Period at which to send VESC frames.
-`calibration.stop_condition`         | int   | -    | Which variant of the SetPos stop condition to use
-`calibration.stop_tolerance`         | int   | deg  | Position tolerance to decide when SetPos can be stopped
-`calibration.log_setpos_diff`        | int   | 0/1  | Whether to log current_position<->target_position during SetPos
-`calibration.use_schedule_hold`      | int   | 0/1  | Whether to delay holding until next received VESC status (to prevent jerk)
+`max_speed`              | float | ERPM | Max speed for SetVelocity mode.[0]
+`max_offset_shift`       | float | deg  | Max value for a single `Offset` command.[0]
+`max_velocity_shift`     | float | deg  | Max rotation away from origin for SetPos mode[1].
+`outdated_duration_s`    | float | s    | Time after which a `VescStatus` frame is considered outdated.
+`speed_timeout_ms`       | float | ms   | Timeout for SetVelocity. If no frame comes from the app in this time, the motor is stopped
+`message_send_period_ms` | float | ms   | Period at which to send VESC frames.
+`stop_condition`         | int   | -    | Which variant of the SetPos stop condition to use
+`stop_tolerance`         | int   | deg  | Position tolerance to decide when SetPos can be stopped
+`log_setpos_diff`        | int   | 0/1  | Whether to log current_position<->target_position during SetPos
+`use_schedule_hold`      | int   | 0/1  | Whether to delay holding until next received VESC status (to prevent jerk), see [FAQ](#faq)
 
-[0] - values outside of range are clamped<br>
+[0] - values outside of range are clamped<br />
 [1] - to rotate more, set origin and try again
+
+It's possible to change parameters while the node is running. For instance:
+```
+ros2 param set calibrate_axis max_speed 3000.0
+```
 
 ## Actions
 
@@ -102,13 +107,18 @@ Sets the origin of a motor at its current position.
 Stops the motor, doesn't hold its position. Use this to abort calibration.
 
 ### ACTION_TYPE_OFFSET [4]
-Rotates the motor by `value` degrees. Cannot rotate more than specifiec in `calibration.max_offset_shift`.
+Rotates the motor by `value` degrees. Cannot rotate more (at once) than specified in `max_offset_shift` param.
+After reaching the target position switches to `Hold`
 
 ### ACTION_TYPE_SET_VELOCITY [5]
 Sets the speed at which to rotate the motor.
 If `0.0` is set, the motor stops and switches to `Hold`.
+Cannot rotate more (in total) than specified in `max_velocity_shift` param.
+If you need to rotate more, set origin and repeat.
 
 ## FAQ
 
 - What happens if motor 2 starts being calibrated when motor 1 is still being calibrated?
     - Only one motor can be calibrated at a time. In this case, motor 1 would be stopped (without hold) and calibration of motor 2 would continue as normal
+- What is hold scheduling?
+    - Normally, when the motor is rotated by velocity and then stopped, it holds at the last known position. It may cause the motor to jerk backwards before stopping. When hold scheduling is enabled, the motor is first stopped, and held only when a new position is received.

--- a/src/calibration_manager/README.md
+++ b/src/calibration_manager/README.md
@@ -78,11 +78,11 @@ Parameter                            | Type  | Unit | Description
 
 [0] - values outside of range are clamped<br />
 [1] - to rotate more, set origin and try again
-
+<!-- 
 It's possible to change parameters while the node is running. For instance:
 ```
 ros2 param set calibrate_axis max_speed 3000.0
-```
+``` -->
 
 ## Actions
 

--- a/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
+++ b/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
@@ -1,0 +1,85 @@
+#ifndef CALIBRATE_AXIS_H
+#define CALIBRATE_AXIS_H
+
+#include "rclcpp/rclcpp.hpp"
+#include "rex_interfaces/msg/vesc_status.hpp"
+#include "rex_interfaces/msg/rover_status.hpp"
+#include "rex_interfaces/msg/calibrate_axis.hpp"
+#include "rex_interfaces/msg/vesc_motor_command.hpp"
+#include "ros_constants/RosCanConstants.hpp"
+#include <cmath>
+#include <limits>
+#include <array>
+#include <map>
+#include <vector>
+#include <algorithm>
+#include <functional>
+
+extern "C"
+{
+#include <libVescCan/VESC.h>
+}
+
+struct PositionStamped
+{
+    float position;
+    rclcpp::Time receivedAt;
+};
+
+struct VelocityStamped
+{
+    int erpm;
+    rclcpp::Time receivedAt;
+};
+
+class CalibrateAxis
+{
+public:
+    CalibrateAxis(rclcpp::Node::SharedPtr &nh);
+
+private:
+    rclcpp::Node::SharedPtr mNh;
+
+    std::array<VESC_Id_t, 4> mCalibrationMotors;
+    std::map<VESC_Id_t, PositionStamped> mMotorPositions;
+    std::map<VESC_Id_t, VelocityStamped> mMotorVelocities;
+    std::map<VESC_Id_t, rclcpp::TimerBase::SharedPtr> mSpeedStopTimers;
+
+    std::map<std::string, float> mFloatParams;
+    std::map<std::string, int> mIntParams;
+
+    float mOffset;
+    VESC_Id_t mCurrentMotorID;
+
+    rex_interfaces::msg::RoverStatus::ConstSharedPtr mLastRoverStatus;
+
+    rclcpp::Publisher<rex_interfaces::msg::VescMotorCommand>::SharedPtr mCalibrationMotorCommandPub;
+    rclcpp::Subscription<rex_interfaces::msg::VescStatus>::SharedPtr mVescStatusSub;
+    rclcpp::Subscription<rex_interfaces::msg::CalibrateAxis>::SharedPtr mCalibrateAxisSub;
+    rclcpp::Subscription<rex_interfaces::msg::RoverStatus>::SharedPtr mRoverStatusSub;
+
+    void initParams();
+
+    rclcpp::node_interfaces::PostSetParametersCallbackHandle::SharedPtr mParamCallbackHandle;
+
+    bool calibrationMotorsContains(VESC_Id_t vescID);
+
+    void handleVescStatus(const rex_interfaces::msg::VescStatus::ConstSharedPtr &msg);
+    void handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis::ConstSharedPtr &msg);
+    void handleRoverStatus(const rex_interfaces::msg::RoverStatus::ConstSharedPtr &msg);
+
+    bool isRecordedVelocityValid(VESC_Id_t vescID);
+    bool isRecordedPositionValid(VESC_Id_t vescID);
+
+    void startTimeout(VESC_Id_t vescID);
+    void cancelTimeout(VESC_Id_t vescID);
+
+    void stopMotor(VESC_Id_t vescID);
+
+    rex_interfaces::msg::VescMotorCommand frameStop(VESC_Id_t vescID);
+    rex_interfaces::msg::VescMotorCommand frameSetOrigin(VESC_Id_t vescID);
+    rex_interfaces::msg::VescMotorCommand frameSetPosition(VESC_Id_t vescID, float position);
+    rex_interfaces::msg::VescMotorCommand frameSetVelocity(VESC_Id_t vescID, float speed);
+};
+
+#endif // CALIBRATE_AXIS_H

--- a/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
+++ b/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
@@ -32,13 +32,24 @@ struct VelocityStamped
     rclcpp::Time receivedAt;
 };
 
+enum class Mode
+{
+    SetVelocity,
+    SetPos,
+    Hold,
+    Nothing
+};
+
 class CalibrateAxis : public rclcpp::Node
 {
 public:
     CalibrateAxis(const rclcpp::NodeOptions &options);
 
 private:
-    rclcpp::Node::SharedPtr mNh;
+    Mode mMode;
+
+    rex_interfaces::msg::VescMotorCommand mFrameToSend;
+    rclcpp::TimerBase::SharedPtr mFrameSender;
 
     std::array<VESC_Id_t, 4> mCalibrationMotors;
     std::map<VESC_Id_t, PositionStamped> mMotorPositions;
@@ -67,6 +78,13 @@ private:
     void handleVescStatus(const rex_interfaces::msg::VescStatus::ConstSharedPtr &msg);
     void handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis::ConstSharedPtr &msg);
     void handleRoverStatus(const rex_interfaces::msg::RoverStatus::ConstSharedPtr &msg);
+
+    void modeNothing();
+    void modeSetPos(VESC_Id_t vescID, float pos);
+    void modeSetVelocity(VESC_Id_t vescID, float velocity);
+    void modeHold(VESC_Id_t vescID);
+
+    bool isTimestampOutdated(rclcpp::Time stamp);
 
     bool isRecordedVelocityValid(VESC_Id_t vescID);
     bool isRecordedPositionValid(VESC_Id_t vescID);

--- a/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
+++ b/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
@@ -48,7 +48,7 @@ private:
 
     std::array<VESC_Id_t, 4> mCalibrationMotors;
     std::map<VESC_Id_t, MotorStatusStamped> mMotorStatuses;
-    std::map<VESC_Id_t, rclcpp::TimerBase::SharedPtr> mSpeedStopTimers;
+    rclcpp::TimerBase::SharedPtr mVelocityTimeoutTimer;
 
     std::map<std::string, float> mFloatParams;
     std::map<std::string, int> mIntParams;
@@ -83,9 +83,8 @@ private:
 
     bool isRecordedStatusValid(VESC_Id_t vescID);
 
-    void initTimeoutTimers();
-    void startTimeout(VESC_Id_t vescID);
-    void cancelTimeout(VESC_Id_t vescID);
+    void startTimeout();
+    void cancelTimeout();
 
     void stopMotor(VESC_Id_t vescID);
 

--- a/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
+++ b/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
@@ -20,14 +20,9 @@ extern "C"
 #include <libVescCan/VESC.h>
 }
 
-struct PositionStamped
+struct MotorStatusStamped
 {
     float position;
-    rclcpp::Time receivedAt;
-};
-
-struct VelocityStamped
-{
     int erpm;
     rclcpp::Time receivedAt;
 };
@@ -52,8 +47,7 @@ private:
     rclcpp::TimerBase::SharedPtr mFrameSender;
 
     std::array<VESC_Id_t, 4> mCalibrationMotors;
-    std::map<VESC_Id_t, PositionStamped> mMotorPositions;
-    std::map<VESC_Id_t, VelocityStamped> mMotorVelocities;
+    std::map<VESC_Id_t, MotorStatusStamped> mMotorStatuses;
     std::map<VESC_Id_t, rclcpp::TimerBase::SharedPtr> mSpeedStopTimers;
 
     std::map<std::string, float> mFloatParams;
@@ -87,8 +81,7 @@ private:
 
     bool isTimestampOutdated(rclcpp::Time stamp);
 
-    bool isRecordedVelocityValid(VESC_Id_t vescID);
-    bool isRecordedPositionValid(VESC_Id_t vescID);
+    bool isRecordedStatusValid(VESC_Id_t vescID);
 
     void initTimeoutTimers();
     void startTimeout(VESC_Id_t vescID);

--- a/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
+++ b/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
@@ -59,7 +59,6 @@ private:
     std::map<std::string, float> mFloatParams;
     std::map<std::string, int> mIntParams;
 
-    float mOffset;
     VESC_Id_t mCurrentMotorID;
 
     rex_interfaces::msg::RoverStatus::ConstSharedPtr mLastRoverStatus;
@@ -83,6 +82,8 @@ private:
     void modeSetPos(VESC_Id_t vescID, float pos);
     void modeSetVelocity(VESC_Id_t vescID, float velocity);
     void modeHold(VESC_Id_t vescID);
+
+    bool checkSetPosEndCondition(const rex_interfaces::msg::VescStatus::ConstSharedPtr &msg);
 
     bool isTimestampOutdated(rclcpp::Time stamp);
 

--- a/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
+++ b/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
@@ -54,6 +54,7 @@ private:
     std::map<std::string, int> mIntParams;
 
     VESC_Id_t mCurrentMotorID;
+    bool mScheduleHold;
 
     rex_interfaces::msg::RoverStatus::ConstSharedPtr mLastRoverStatus;
 

--- a/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
+++ b/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
@@ -71,6 +71,7 @@ private:
     bool isRecordedVelocityValid(VESC_Id_t vescID);
     bool isRecordedPositionValid(VESC_Id_t vescID);
 
+    void initTimeoutTimers();
     void startTimeout(VESC_Id_t vescID);
     void cancelTimeout(VESC_Id_t vescID);
 

--- a/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
+++ b/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
@@ -32,10 +32,10 @@ struct VelocityStamped
     rclcpp::Time receivedAt;
 };
 
-class CalibrateAxis
+class CalibrateAxis : public rclcpp::Node
 {
 public:
-    CalibrateAxis(rclcpp::Node::SharedPtr &nh);
+    CalibrateAxis(const rclcpp::NodeOptions &options);
 
 private:
     rclcpp::Node::SharedPtr mNh;

--- a/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
+++ b/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
@@ -101,6 +101,7 @@ private:
     bool checkSetPosEndCondition(const rex_interfaces::msg::VescStatus::ConstSharedPtr &msg);
     bool isTimestampOutdated(rclcpp::Time stamp);
     bool isRecordedStatusValid(VESC_Id_t vescID);
+    void scheduleHold(VESC_Id_t vescID);
 };
 
 template <typename T>

--- a/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
+++ b/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
@@ -47,7 +47,7 @@ private:
     rex_interfaces::msg::VescMotorCommand mFrameToSend;
     rclcpp::TimerBase::SharedPtr mFrameSender;
 
-    std::array<VESC_Id_t, 4> mCalibrationMotors;
+    std::vector<VESC_Id_t> mCalibrationMotors;
     std::map<VESC_Id_t, MotorStatusStamped> mMotorStatuses;
     rclcpp::TimerBase::SharedPtr mVelocityTimeoutTimer;
 
@@ -58,6 +58,7 @@ private:
 
     rex_interfaces::msg::RoverStatus::ConstSharedPtr mLastRoverStatus;
     rex_interfaces::msg::BatteryInfo::ConstSharedPtr mLastBatteryInfo;
+    float mSetPosStartingPosition;
 
     rclcpp::Publisher<rex_interfaces::msg::VescMotorCommand>::SharedPtr mCalibrationMotorCommandPub;
     rclcpp::Subscription<rex_interfaces::msg::VescStatus>::SharedPtr mVescStatusSub;
@@ -76,7 +77,7 @@ private:
 
     // ######################### MODES #########################
     void modeNothing();
-    void modeSetPos(VESC_Id_t vescID, float pos);
+    void modeSetPos(VESC_Id_t vescID, float pos, bool dontSaveStartingPos);
     void modeSetVelocity(VESC_Id_t vescID, float velocity);
     void modeHold(VESC_Id_t vescID);
 
@@ -96,10 +97,11 @@ private:
     void sendFrame();
 
     // ######################### UTILITY #########################
-    bool calibrationMotorsContains(VESC_Id_t vescID);
+    bool isCalibrationAllowedForMotor(VESC_Id_t vescID);
     bool checkSetPosEndCondition(const rex_interfaces::msg::VescStatus::ConstSharedPtr &msg);
     bool isTimestampOutdated(rclcpp::Time stamp);
     bool isRecordedStatusValid(VESC_Id_t vescID);
+    void lockMotor(VESC_Id_t vescID);
 };
 
 template <typename T>

--- a/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
+++ b/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
@@ -43,7 +43,6 @@ public:
 
 private:
     Mode mMode;
-    bool mHoldScheduled;
 
     rex_interfaces::msg::VescMotorCommand mFrameToSend;
     rclcpp::TimerBase::SharedPtr mFrameSender;
@@ -101,7 +100,6 @@ private:
     bool checkSetPosEndCondition(const rex_interfaces::msg::VescStatus::ConstSharedPtr &msg);
     bool isTimestampOutdated(rclcpp::Time stamp);
     bool isRecordedStatusValid(VESC_Id_t vescID);
-    void scheduleHold(VESC_Id_t vescID);
 };
 
 template <typename T>

--- a/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
+++ b/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
@@ -4,6 +4,7 @@
 #include "rclcpp/rclcpp.hpp"
 #include "rex_interfaces/msg/vesc_status.hpp"
 #include "rex_interfaces/msg/rover_status.hpp"
+#include "rex_interfaces/msg/battery_info.hpp"
 #include "rex_interfaces/msg/calibrate_axis.hpp"
 #include "rex_interfaces/msg/vesc_motor_command.hpp"
 #include "ros_constants/RosCanConstants.hpp"
@@ -57,11 +58,13 @@ private:
     VESC_Id_t mCurrentMotorID;
 
     rex_interfaces::msg::RoverStatus::ConstSharedPtr mLastRoverStatus;
+    rex_interfaces::msg::BatteryInfo::ConstSharedPtr mLastBatteryInfo;
 
     rclcpp::Publisher<rex_interfaces::msg::VescMotorCommand>::SharedPtr mCalibrationMotorCommandPub;
     rclcpp::Subscription<rex_interfaces::msg::VescStatus>::SharedPtr mVescStatusSub;
     rclcpp::Subscription<rex_interfaces::msg::CalibrateAxis>::SharedPtr mCalibrateAxisSub;
     rclcpp::Subscription<rex_interfaces::msg::RoverStatus>::SharedPtr mRoverStatusSub;
+    rclcpp::Subscription<rex_interfaces::msg::BatteryInfo>::SharedPtr mBatteryInfoSub;
 
     void initParams();
     rclcpp::node_interfaces::PostSetParametersCallbackHandle::SharedPtr mParamCallbackHandle;
@@ -70,6 +73,7 @@ private:
     void handleVescStatus(const rex_interfaces::msg::VescStatus::ConstSharedPtr &msg);
     void handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis::ConstSharedPtr &msg);
     void handleRoverStatus(const rex_interfaces::msg::RoverStatus::ConstSharedPtr &msg);
+    void handleBatteryInfo(const rex_interfaces::msg::BatteryInfo::ConstSharedPtr &msg);
 
     // ######################### MODES #########################
     void modeNothing();
@@ -98,5 +102,8 @@ private:
     bool isTimestampOutdated(rclcpp::Time stamp);
     bool isRecordedStatusValid(VESC_Id_t vescID);
 };
+
+template <typename T>
+int signum(T val);
 
 #endif // CALIBRATE_AXIS_H

--- a/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
+++ b/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
@@ -106,6 +106,7 @@ private:
     void lockMotor(VESC_Id_t vescID);
     float getTargetPosFromSetPosFrame(const rex_interfaces::msg::VescMotorCommand msg);
     bool isBlackMushroomPressed(const rex_interfaces::msg::BatteryInfo::ConstSharedPtr &msg);
+    bool isCalibrationAllowedByRoverStatus(const rex_interfaces::msg::RoverStatus::ConstSharedPtr &msg) const;
 };
 
 template <typename T>

--- a/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
+++ b/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
@@ -42,6 +42,7 @@ public:
 
 private:
     Mode mMode;
+    bool mHoldScheduled;
 
     rex_interfaces::msg::VescMotorCommand mFrameToSend;
     rclcpp::TimerBase::SharedPtr mFrameSender;
@@ -54,7 +55,6 @@ private:
     std::map<std::string, int> mIntParams;
 
     VESC_Id_t mCurrentMotorID;
-    bool mScheduleHold;
 
     rex_interfaces::msg::RoverStatus::ConstSharedPtr mLastRoverStatus;
 
@@ -64,35 +64,39 @@ private:
     rclcpp::Subscription<rex_interfaces::msg::RoverStatus>::SharedPtr mRoverStatusSub;
 
     void initParams();
-
     rclcpp::node_interfaces::PostSetParametersCallbackHandle::SharedPtr mParamCallbackHandle;
 
-    bool calibrationMotorsContains(VESC_Id_t vescID);
-
+    // ######################### MSG HANDLERS #########################
     void handleVescStatus(const rex_interfaces::msg::VescStatus::ConstSharedPtr &msg);
     void handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis::ConstSharedPtr &msg);
     void handleRoverStatus(const rex_interfaces::msg::RoverStatus::ConstSharedPtr &msg);
 
+    // ######################### MODES #########################
     void modeNothing();
     void modeSetPos(VESC_Id_t vescID, float pos);
     void modeSetVelocity(VESC_Id_t vescID, float velocity);
     void modeHold(VESC_Id_t vescID);
 
-    bool checkSetPosEndCondition(const rex_interfaces::msg::VescStatus::ConstSharedPtr &msg);
-
-    bool isTimestampOutdated(rclcpp::Time stamp);
-
-    bool isRecordedStatusValid(VESC_Id_t vescID);
-
+    // ######################### TIMER-RELATED #########################
     void startTimeout();
     void cancelTimeout();
+    void timeoutTimerTick();
 
     void stopMotor(VESC_Id_t vescID);
 
+    // ######################### CAN FRAMES #########################
     rex_interfaces::msg::VescMotorCommand frameStop(VESC_Id_t vescID);
     rex_interfaces::msg::VescMotorCommand frameSetOrigin(VESC_Id_t vescID);
     rex_interfaces::msg::VescMotorCommand frameSetPosition(VESC_Id_t vescID, float position);
     rex_interfaces::msg::VescMotorCommand frameSetVelocity(VESC_Id_t vescID, float speed);
+
+    void sendFrame();
+
+    // ######################### UTILITY #########################
+    bool calibrationMotorsContains(VESC_Id_t vescID);
+    bool checkSetPosEndCondition(const rex_interfaces::msg::VescStatus::ConstSharedPtr &msg);
+    bool isTimestampOutdated(rclcpp::Time stamp);
+    bool isRecordedStatusValid(VESC_Id_t vescID);
 };
 
 #endif // CALIBRATE_AXIS_H

--- a/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
+++ b/src/calibration_manager/include/calibration_manager/CalibrateAxis.hpp
@@ -58,7 +58,9 @@ private:
 
     rex_interfaces::msg::RoverStatus::ConstSharedPtr mLastRoverStatus;
     rex_interfaces::msg::BatteryInfo::ConstSharedPtr mLastBatteryInfo;
-    float mSetPosStartingPosition;
+
+    // Used during SetPos to track distance left to target. Used for hardware failure detection.
+    float mSetPosDistanceToTarget;
 
     rclcpp::Publisher<rex_interfaces::msg::VescMotorCommand>::SharedPtr mCalibrationMotorCommandPub;
     rclcpp::Subscription<rex_interfaces::msg::VescStatus>::SharedPtr mVescStatusSub;
@@ -77,7 +79,7 @@ private:
 
     // ######################### MODES #########################
     void modeNothing();
-    void modeSetPos(VESC_Id_t vescID, float pos, bool dontSaveStartingPos);
+    void modeSetPos(VESC_Id_t vescID, float pos);
     void modeSetVelocity(VESC_Id_t vescID, float velocity);
     void modeHold(VESC_Id_t vescID);
 
@@ -102,6 +104,8 @@ private:
     bool isTimestampOutdated(rclcpp::Time stamp);
     bool isRecordedStatusValid(VESC_Id_t vescID);
     void lockMotor(VESC_Id_t vescID);
+    float getTargetPosFromSetPosFrame(const rex_interfaces::msg::VescMotorCommand msg);
+    bool isBlackMushroomPressed(const rex_interfaces::msg::BatteryInfo::ConstSharedPtr &msg);
 };
 
 template <typename T>

--- a/src/calibration_manager/launch/calibration_manager.yaml
+++ b/src/calibration_manager/launch/calibration_manager.yaml
@@ -10,10 +10,6 @@ launch:
           name: calibrate_axis
           namespace: "raptor"
           param:
-            - name: "calibration.pos_speed"
-              value: 3.0
-            - name: "calibration.pos_acceleration"
-              value: 3.0
             - name: "calibration.max_speed"
               value: 5000.0
             - name: "calibration.max_offset_shift"

--- a/src/calibration_manager/launch/calibration_manager.yaml
+++ b/src/calibration_manager/launch/calibration_manager.yaml
@@ -22,3 +22,5 @@ launch:
               value: 2
             - name: "calibration.stop_tolerance"
               value: 1.0
+            - name: "calibration.log_setpos_diff"
+              value: 0

--- a/src/calibration_manager/launch/calibration_manager.yaml
+++ b/src/calibration_manager/launch/calibration_manager.yaml
@@ -1,0 +1,24 @@
+launch:
+  - node_container:
+      pkg: rclcpp_components
+      exec: component_container
+      name: calibration_manager_container
+      namespace: "raptor"
+      composable_node:
+        - pkg: calibration_manager
+          plugin: CalibrateAxis
+          name: calibrate_axis
+          namespace: "raptor"
+          param:
+            - name: "calibration.pos_speed"
+              value: 3.0
+            - name: "calibration.pos_acceleration"
+              value: 3.0
+            - name: "calibration.max_speed"
+              value: 30.0
+            - name: "calibration.max_offset_shift"
+              value: 30.0
+            - name: "calibration.outdated_duration_s"
+              value: 0.3
+            - name: "calibration.speed_timeout_ms"
+              value: 500

--- a/src/calibration_manager/launch/calibration_manager.yaml
+++ b/src/calibration_manager/launch/calibration_manager.yaml
@@ -15,10 +15,14 @@ launch:
             - name: "calibration.pos_acceleration"
               value: 3.0
             - name: "calibration.max_speed"
-              value: 30.0
+              value: 5000.0
             - name: "calibration.max_offset_shift"
               value: 30.0
             - name: "calibration.outdated_duration_s"
               value: 0.3
             - name: "calibration.speed_timeout_ms"
               value: 500
+            - name: "calibration.stop_condition"
+              value: 2
+            - name: "calibration.stop_tolerance"
+              value: 1.0

--- a/src/calibration_manager/launch/calibration_manager.yaml
+++ b/src/calibration_manager/launch/calibration_manager.yaml
@@ -24,3 +24,5 @@ launch:
               value: 1.0
             - name: "calibration.log_setpos_diff"
               value: 0
+            - name: "calibration.use_schedule_hold"
+              value: 1

--- a/src/calibration_manager/launch/calibration_manager.yaml
+++ b/src/calibration_manager/launch/calibration_manager.yaml
@@ -19,7 +19,7 @@ launch:
             - name: "calibration.speed_timeout_ms"
               value: 500
             - name: "calibration.stop_condition"
-              value: 2
+              value: 3
             - name: "calibration.stop_tolerance"
               value: 1.0
             - name: "calibration.log_setpos_diff"

--- a/src/calibration_manager/launch/calibration_manager.yaml
+++ b/src/calibration_manager/launch/calibration_manager.yaml
@@ -10,19 +10,19 @@ launch:
           name: calibrate_axis
           namespace: "raptor"
           param:
-            - name: "calibration.max_speed"
+            - name: "max_speed"
               value: 5000.0
-            - name: "calibration.max_offset_shift"
+            - name: "max_offset_shift"
               value: 30.0
-            - name: "calibration.outdated_duration_s"
+            - name: "outdated_duration_s"
               value: 0.3
-            - name: "calibration.speed_timeout_ms"
+            - name: "speed_timeout_ms"
               value: 500
-            - name: "calibration.stop_condition"
+            - name: "stop_condition"
               value: 3
-            - name: "calibration.stop_tolerance"
+            - name: "stop_tolerance"
               value: 1.0
-            - name: "calibration.log_setpos_diff"
+            - name: "log_setpos_diff"
               value: 0
-            - name: "calibration.use_schedule_hold"
+            - name: "use_schedule_hold"
               value: 1

--- a/src/calibration_manager/launch/calibration_manager.yaml
+++ b/src/calibration_manager/launch/calibration_manager.yaml
@@ -24,5 +24,3 @@ launch:
               value: 1.0
             - name: "log_setpos_diff"
               value: 0
-            - name: "use_schedule_hold"
-              value: 1

--- a/src/calibration_manager/launch/calibration_manager.yaml
+++ b/src/calibration_manager/launch/calibration_manager.yaml
@@ -19,7 +19,7 @@ launch:
             - name: "outdated_duration_s"
               value: 0.3
             - name: "stop_tolerance"
-              value: 1.0
+              value: 0.3
             - name: "speed_timeout_ms"
               value: 500
             - name: "log_setpos_diff"

--- a/src/calibration_manager/launch/calibration_manager.yaml
+++ b/src/calibration_manager/launch/calibration_manager.yaml
@@ -11,16 +11,16 @@ launch:
           namespace: "raptor"
           param:
             - name: "max_speed"
-              value: 5000.0
+              value: 10000.0
             - name: "max_offset_shift"
+              value: 30.0
+            - name: "max_velocity_shift"
               value: 30.0
             - name: "outdated_duration_s"
               value: 0.3
-            - name: "speed_timeout_ms"
-              value: 500
-            - name: "stop_condition"
-              value: 3
             - name: "stop_tolerance"
               value: 1.0
+            - name: "speed_timeout_ms"
+              value: 500
             - name: "log_setpos_diff"
               value: 0

--- a/src/calibration_manager/package.xml
+++ b/src/calibration_manager/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>calibration_manager</name>
+  <version>0.1.0</version>
+  <description>A package handling the calibration of wheel and manipulator motors.</description>
+  <maintainer email="adik07m@gmail.com">Adam Marciniak</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>ros_constants</depend>
+  <build_depend>libVescCan</build_depend>
+  <build_depend>rex_interfaces</build_depend>
+  <exec_depend>rex_interfaces</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/calibration_manager/package.xml
+++ b/src/calibration_manager/package.xml
@@ -11,6 +11,7 @@
 
   <depend>rclcpp</depend>
   <depend>ros_constants</depend>
+  <depend>rclcpp_components</depend>
   <build_depend>libVescCan</build_depend>
   <build_depend>rex_interfaces</build_depend>
   <exec_depend>rex_interfaces</exec_depend>

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -1,8 +1,5 @@
 #include "calibration_manager/CalibrateAxis.hpp"
 
-const std::string CALIBRATION_POS_SPEED = "calibration.pos_speed";
-const std::string CALIBRATION_POS_ACCELERATION = "calibration.pos_acceleration";
-
 const std::string CALIBRATION_MAX_SPEED = "calibration.max_speed";
 const std::string CALIBRATION_MAX_OFFSET_SHIFT = "calibration.max_offset_shift";
 const std::string CALIBRATION_MAX_VELOCITY_SHIFT = "calibration.max_velocity_shift";
@@ -74,8 +71,6 @@ CalibrateAxis::CalibrateAxis(const rclcpp::NodeOptions &options) : Node("calibra
 void CalibrateAxis::initParams()
 {
 	mFloatParams = {
-		{CALIBRATION_POS_SPEED, 3.0f},
-		{CALIBRATION_POS_ACCELERATION, 3.0f},
 		{CALIBRATION_MAX_SPEED, 3.0f},
 		{CALIBRATION_MAX_OFFSET_SHIFT, 30.0f},
 		{CALIBRATION_MAX_VELOCITY_SHIFT, 30.0f},

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -173,7 +173,9 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 	// If motor is moving by Offset, only STOP and CANCEL are fine
 	if (mMode == Mode::SetVelocity)
 	{
-		if (msg->action_type != CalibrateMsg::ACTION_TYPE_SET_VELOCITY && msg->action_type != CalibrateMsg::ACTION_TYPE_STOP && msg->action_type != CalibrateMsg::ACTION_TYPE_CANCEL)
+		if (msg->action_type != CalibrateMsg::ACTION_TYPE_SET_VELOCITY &&
+			msg->action_type != CalibrateMsg::ACTION_TYPE_STOP &&
+			msg->action_type != CalibrateMsg::ACTION_TYPE_CANCEL)
 		{
 			RCLCPP_INFO(this->get_logger(), "Calibration request rejected, the motor is still moving");
 			return;
@@ -302,6 +304,14 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 
 void CalibrateAxis::handleRoverStatus(const rex_interfaces::msg::RoverStatus::ConstSharedPtr &msg)
 {
+	if (mLastRoverStatus &&
+		mLastRoverStatus->control_mode == rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP &&
+		msg->control_mode != rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP)
+	{
+		modeNothing();
+		mOffset = NaN;
+		mCurrentMotorID = 0;
+	}
 	mLastRoverStatus = msg;
 }
 

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -1,0 +1,352 @@
+#include "calibration_manager/CalibrateAxis.hpp"
+
+const std::string CALIBRATION_POS_SPEED = "calibration.pos_speed";
+const std::string CALIBRATION_POS_ACCELERATION = "calibration.pos_acceleration";
+
+const std::string CALIBRATION_MAX_SPEED = "calibration.max_speed";
+const std::string CALIBRATION_MAX_OFFSET_SHIFT = "calibration.max_offset_shift";
+
+const std::string CALIBRATION_OUTDATED_DURATION_S = "calibration.outdated_duration_s";
+const std::string CALIBRATION_SPEED_TIMEOUT_MS = "calibration.speed_timeout_ms";
+
+constexpr float NaN = std::numeric_limits<float>::quiet_NaN();
+
+CalibrateAxis::CalibrateAxis(rclcpp::Node::SharedPtr &nh) : mNh(nh)
+{
+	const rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(256));
+
+	initParams();
+
+	mCalibrationMotorCommandPub = mNh->create_publisher<rex_interfaces::msg::VescMotorCommand>(
+		RosCanConstants::RosTopics::can_calibration_motor_command, qos);
+	mVescStatusSub = mNh->create_subscription<rex_interfaces::msg::VescStatus>(
+		RosCanConstants::RosTopics::can_vesc_status,
+		qos, std::bind(&CalibrateAxis::handleVescStatus, this, std::placeholders::_1));
+	mCalibrateAxisSub = mNh->create_subscription<rex_interfaces::msg::CalibrateAxis>(
+		RosCanConstants::RosTopics::mqtt_calibrate_axis,
+		qos, std::bind(&CalibrateAxis::handleCalibrateAxis, this, std::placeholders::_1));
+	mRoverStatusSub = mNh->create_subscription<rex_interfaces::msg::RoverStatus>(
+		RosCanConstants::RosTopics::mqtt_rover_status,
+		qos, std::bind(&CalibrateAxis::handleRoverStatus, this, std::placeholders::_1));
+
+	mCalibrationMotors = {
+		RosCanConstants::VescIds::front_left_stepper,
+		RosCanConstants::VescIds::front_right_stepper,
+		RosCanConstants::VescIds::rear_left_stepper,
+		RosCanConstants::VescIds::rear_right_stepper,
+	};
+
+	mOffset = NaN;
+	mCurrentMotorID = 0;
+
+	RCLCPP_DEBUG(mNh->get_logger(), "Calibration module started.");
+};
+
+void CalibrateAxis::initParams()
+{
+	mFloatParams = {
+		{CALIBRATION_POS_SPEED, 3.0f},
+		{CALIBRATION_POS_ACCELERATION, 3.0f},
+		{CALIBRATION_MAX_SPEED, 3.0f},
+		{CALIBRATION_MAX_OFFSET_SHIFT, 30.0f},
+		{CALIBRATION_OUTDATED_DURATION_S, 0.3f}};
+	for (auto &[name, value] : mFloatParams)
+	{
+		mNh->declare_parameter(name, value);
+		mFloatParams[name] = mNh->get_parameter(name).as_double();
+	}
+
+	mIntParams = {
+		{CALIBRATION_SPEED_TIMEOUT_MS, 500}};
+	for (auto &[name, value] : mIntParams)
+	{
+		mNh->declare_parameter(name, value);
+		mIntParams[name] = mNh->get_parameter(name).as_int();
+	}
+
+	mParamCallbackHandle = mNh->add_post_set_parameters_callback(
+		[this](const std::vector<rclcpp::Parameter> &params)
+		{
+			for (const auto &param : params)
+			{
+				const std::string name = param.get_name();
+				if (mFloatParams.count(name))
+				{
+					mFloatParams[name] = param.as_double();
+				}
+				else if (mIntParams.count(name))
+				{
+					mIntParams[name] = param.as_int();
+				}
+			}
+		});
+}
+
+bool CalibrateAxis::calibrationMotorsContains(VESC_Id_t vescID)
+{
+	return std::find(mCalibrationMotors.begin(), mCalibrationMotors.end(), vescID) != mCalibrationMotors.end();
+}
+
+void CalibrateAxis::handleVescStatus(const rex_interfaces::msg::VescStatus::ConstSharedPtr &msg)
+{
+	if (!calibrationMotorsContains(msg->vesc_id))
+	{
+		return;
+	}
+	rclcpp::Time now = rclcpp::Clock().now();
+	mMotorPositions[msg->vesc_id] = {msg->pid_pos, now};
+	mMotorVelocities[msg->vesc_id] = {msg->erpm, now};
+}
+
+void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis::ConstSharedPtr &msg)
+{
+	using CalibrateMsg = rex_interfaces::msg::CalibrateAxis;
+
+	if (!mLastRoverStatus || mLastRoverStatus->control_mode != rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP)
+	{
+		RCLCPP_ERROR(mNh->get_logger(), "Rover not in ESTOP, calibration not permitted.");
+		return;
+	}
+
+	if (!calibrationMotorsContains(msg->vesc_id))
+	{
+		RCLCPP_ERROR(mNh->get_logger(), "Attempted to calibrate motor with invalid VESC ID: %#x", msg->vesc_id);
+		return;
+	}
+
+	// If velocity missing or outdated
+	if (!isRecordedVelocityValid(msg->vesc_id))
+	{
+		return;
+	}
+
+	// If motor is still moving, only STOP or CANCEL are fine
+	if (std::abs(mMotorVelocities[msg->vesc_id].erpm) > 0)
+	{
+		if (!(msg->action_type == CalibrateMsg::ACTION_TYPE_STOP || msg->action_type == CalibrateMsg::ACTION_TYPE_CANCEL))
+		{
+			RCLCPP_DEBUG(mNh->get_logger(), "Calibration request rejected, the motor is still moving");
+			return;
+		}
+	}
+
+	// --------------------
+
+	// Action any other than OFFSET
+	if (msg->action_type != rex_interfaces::msg::CalibrateAxis::ACTION_TYPE_OFFSET)
+	{
+		mOffset = NaN;
+	}
+
+	// Message to a different motor
+	if (mCurrentMotorID != msg->vesc_id)
+	{
+		if (mCurrentMotorID)
+			stopMotor(mCurrentMotorID);
+		mCurrentMotorID = msg->vesc_id;
+		mOffset = NaN;
+	}
+
+	// --------------------
+
+	rex_interfaces::msg::VescMotorCommand fr;
+	float offsetShift;
+	switch (msg->action_type)
+	{
+	case CalibrateMsg::ACTION_TYPE_STOP:
+		stopMotor(msg->vesc_id);
+		break;
+
+	case CalibrateMsg::ACTION_TYPE_RETURN_TO_ORIGIN:
+		fr = frameSetPosition(msg->vesc_id, 0.0f);
+		mOffset = 0.0;
+		mCalibrationMotorCommandPub->publish(fr);
+		break;
+
+	case CalibrateMsg::ACTION_TYPE_CONFIRM:
+		stopMotor(msg->vesc_id);
+		fr = frameSetOrigin(msg->vesc_id);
+		mCalibrationMotorCommandPub->publish(fr);
+		mOffset = NaN;
+		mCurrentMotorID = 0;
+		break;
+
+	case CalibrateMsg::ACTION_TYPE_CANCEL:
+		stopMotor(msg->vesc_id);
+		mOffset = NaN;
+		mCurrentMotorID = 0;
+		break;
+
+	case CalibrateMsg::ACTION_TYPE_OFFSET:
+		if (std::isnan(mOffset))
+		{
+			if (!isRecordedPositionValid(msg->vesc_id))
+			{
+				return;
+			}
+			// Copy realtime-tracked position
+			mOffset = mMotorPositions[msg->vesc_id].position;
+		}
+
+		// Limit value
+		offsetShift = msg->value;
+		if (std::abs(offsetShift) > mFloatParams[CALIBRATION_MAX_OFFSET_SHIFT])
+		{
+			RCLCPP_WARN(mNh->get_logger(), "Calibration: provided a relative offset that's too large (max %f)", mFloatParams[CALIBRATION_MAX_OFFSET_SHIFT]);
+			offsetShift = std::clamp(offsetShift, -mFloatParams[CALIBRATION_MAX_OFFSET_SHIFT], mFloatParams[CALIBRATION_MAX_OFFSET_SHIFT]);
+		}
+
+		mOffset += offsetShift;
+		fr = frameSetPosition(msg->vesc_id, mOffset);
+		mCalibrationMotorCommandPub->publish(fr);
+		break;
+
+	case CalibrateMsg::ACTION_TYPE_SET_VELOCITY:
+		// Limit value
+		float velocity = msg->value;
+		if (std::abs(velocity) > mFloatParams[CALIBRATION_MAX_SPEED])
+		{
+			RCLCPP_WARN(mNh->get_logger(), "Calibration: provided a velocity that's too large (max %f)", mFloatParams[CALIBRATION_MAX_SPEED]);
+			velocity = std::clamp(velocity, -mFloatParams[CALIBRATION_MAX_SPEED], mFloatParams[CALIBRATION_MAX_SPEED]);
+		}
+
+		// Handle the stop timers
+		if (velocity == 0.0f)
+			cancelTimeout(msg->vesc_id);
+		else
+			startTimeout(msg->vesc_id);
+
+		fr = frameSetVelocity(msg->vesc_id, velocity);
+		mCalibrationMotorCommandPub->publish(fr);
+		break;
+	}
+}
+
+void CalibrateAxis::handleRoverStatus(const rex_interfaces::msg::RoverStatus::ConstSharedPtr &msg)
+{
+	mLastRoverStatus = msg;
+}
+
+bool CalibrateAxis::isRecordedVelocityValid(VESC_Id_t vescID)
+{
+	// Checks if the tracked velocity is missing or outdated
+
+	if (!mMotorVelocities.count(vescID))
+	{
+		RCLCPP_WARN(mNh->get_logger(), "Calibration failed, no recorded velocity for motor with ID %#x", vescID);
+		return false;
+	}
+	rclcpp::Time now = rclcpp::Clock().now();
+	if ((now - mMotorVelocities[vescID].receivedAt).seconds() > mFloatParams[CALIBRATION_OUTDATED_DURATION_S])
+	{
+		RCLCPP_WARN(mNh->get_logger(), "Calibration failed, recorded velocity for motor with id %#x is outdated", vescID);
+		return false;
+	}
+	return true;
+}
+
+bool CalibrateAxis::isRecordedPositionValid(VESC_Id_t vescID)
+{
+	// Checks if the tracked position is missing or outdated
+
+	if (!mMotorPositions.count(vescID))
+	{
+		RCLCPP_WARN(mNh->get_logger(), "Calibration failed, no recorded position for motor with ID %#x", vescID);
+		return false;
+	}
+
+	rclcpp::Time now = rclcpp::Clock().now();
+	if ((now - mMotorPositions[vescID].receivedAt).seconds() > mFloatParams[CALIBRATION_OUTDATED_DURATION_S])
+	{
+		RCLCPP_WARN(mNh->get_logger(), "Calibration failed, recorded position for motor with id %#x is outdated", vescID);
+		return false;
+	}
+	return true;
+}
+
+void CalibrateAxis::startTimeout(VESC_Id_t vescID)
+{
+	// Cancel previous timeout
+	cancelTimeout(vescID);
+	mSpeedStopTimers[vescID] = mNh->create_timer(
+		std::chrono::milliseconds(mIntParams[CALIBRATION_SPEED_TIMEOUT_MS]),
+		[this, vescID]()
+		{
+			stopMotor(vescID);
+			// cancelTimeout(vescID); // Redundant as stopMotor already calls cancelTimeout()
+		});
+}
+
+void CalibrateAxis::cancelTimeout(VESC_Id_t vescID)
+{
+	// Check if ID in map. If it is, check if the pointer is non-null. If not, cancel.
+	auto iterator = mSpeedStopTimers.find(vescID);
+	if (iterator == mSpeedStopTimers.end() || !iterator->second || iterator->second->is_canceled())
+	{
+		// Nothing to cancel
+		return;
+	}
+	iterator->second->cancel();
+}
+
+void CalibrateAxis::stopMotor(VESC_Id_t vescID)
+{
+	cancelTimeout(vescID);
+
+	rex_interfaces::msg::VescMotorCommand fr = frameStop(vescID);
+	mCalibrationMotorCommandPub->publish(fr);
+}
+
+rex_interfaces::msg::VescMotorCommand CalibrateAxis::frameStop(VESC_Id_t vescID)
+{
+	rex_interfaces::msg::VescMotorCommand msg;
+
+	msg.vesc_id = vescID;
+	msg.command_id = VESC_COMMAND_SET_CURRENT;
+	msg.set_value = 0.0f;
+
+	msg.header.stamp = rclcpp::Clock().now();
+
+	return msg;
+}
+
+rex_interfaces::msg::VescMotorCommand CalibrateAxis::frameSetOrigin(VESC_Id_t vescID)
+{
+	rex_interfaces::msg::VescMotorCommand msg;
+
+	msg.vesc_id = vescID;
+	msg.command_id = VESC_COMMAND_SET_ORIGIN;
+	msg.set_origin_data = 0.0f;
+
+	msg.header.stamp = rclcpp::Clock().now();
+
+	return msg;
+}
+
+rex_interfaces::msg::VescMotorCommand CalibrateAxis::frameSetPosition(VESC_Id_t vescID, float position)
+{
+	rex_interfaces::msg::VescMotorCommand msg;
+
+	msg.vesc_id = vescID;
+	msg.command_id = VESC_COMMAND_SET_POS_SPEED_LOOP;
+	msg.set_pos_speed_loop_position = position;
+	msg.set_pos_speed_loop_speed = mFloatParams[CALIBRATION_POS_SPEED];
+	msg.set_pos_speed_loop_acceleration = mFloatParams[CALIBRATION_POS_ACCELERATION];
+
+	msg.header.stamp = rclcpp::Clock().now();
+
+	return msg;
+}
+
+rex_interfaces::msg::VescMotorCommand CalibrateAxis::frameSetVelocity(VESC_Id_t vescID, float velocity)
+{
+	rex_interfaces::msg::VescMotorCommand msg;
+
+	msg.vesc_id = vescID;
+	msg.command_id = VESC_COMMAND_SET_RPM;
+	msg.set_value = velocity;
+
+	msg.header.stamp = rclcpp::Clock().now();
+
+	return msg;
+}

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -69,6 +69,7 @@ CalibrateAxis::CalibrateAxis(const rclcpp::NodeOptions &options) : Node("calibra
 			{
 				RCLCPP_ERROR(this->get_logger(), "Error: timeout timer wasn't cancelled correctly!");
 			}
+			RCLCPP_INFO(this->get_logger(), "Motor [%d] stopped by timeout", mCurrentMotorID);
 			stopMotor(mCurrentMotorID);
 			modeHold(mCurrentMotorID);
 			// stopMotor cancels the timer
@@ -153,6 +154,7 @@ void CalibrateAxis::handleVescStatus(const rex_interfaces::msg::VescStatus::Cons
 		signum(mFrameToSend.set_value) == signum(msg->precise_pos) // Moving away from origin
 	)
 	{
+		RCLCPP_INFO(this->get_logger(), "Max velocity shift reached, snapping to %d", signum(msg->precise_pos) * (mFloatParams[CALIBRATION_MAX_VELOCITY_SHIFT] + 1));
 		// Snap to max shift
 		// +1 so that SetVelocity frames in the outer direction will still be rejected
 		modeSetPos(msg->vesc_id, signum(msg->precise_pos) * (mFloatParams[CALIBRATION_MAX_VELOCITY_SHIFT] + 1));
@@ -334,6 +336,7 @@ void CalibrateAxis::handleRoverStatus(const rex_interfaces::msg::RoverStatus::Co
 
 void CalibrateAxis::modeNothing()
 {
+	RCLCPP_INFO(this->get_logger(), "MODE Nothing");
 	mFrameToSend = rex_interfaces::msg::VescMotorCommand();
 	mMode = Mode::Nothing;
 	mCurrentMotorID = 0;
@@ -341,6 +344,7 @@ void CalibrateAxis::modeNothing()
 
 void CalibrateAxis::modeSetPos(VESC_Id_t vescID, float pos)
 {
+	RCLCPP_INFO(this->get_logger(), "MODE SetPos [%d]: %d", vescID, pos);
 	mFrameToSend = frameSetPosition(vescID, pos);
 	mMode = Mode::SetPos;
 	mCurrentMotorID = vescID;
@@ -348,6 +352,7 @@ void CalibrateAxis::modeSetPos(VESC_Id_t vescID, float pos)
 
 void CalibrateAxis::modeSetVelocity(VESC_Id_t vescID, float velocity)
 {
+	RCLCPP_INFO(this->get_logger(), "MODE SetVelocity [%d]: %d", vescID, velocity);
 	mFrameToSend = frameSetVelocity(vescID, velocity);
 	mMode = Mode::SetVelocity;
 	mCurrentMotorID = vescID;
@@ -370,6 +375,7 @@ void CalibrateAxis::modeHold(VESC_Id_t vescID)
 		mFrameToSend = frameSetPosition(vescID, mMotorStatuses[vescID].position);
 		mMode = Mode::Hold;
 	}
+	RCLCPP_INFO(this->get_logger(), "MODE Hold [%d]: %d", vescID, mFrameToSend.set_value * 100.0);
 	mCurrentMotorID = vescID;
 }
 

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -312,6 +312,8 @@ void CalibrateAxis::handleRoverStatus(const rex_interfaces::msg::RoverStatus::Co
 		mLastRoverStatus->control_mode == rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP &&
 		msg->control_mode != rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP)
 	{
+		if (mMode == Mode::SetPos || mMode == Mode::SetVelocity)
+			stopMotor(mCurrentMotorID);
 		modeNothing();
 	}
 	mLastRoverStatus = msg;

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -94,7 +94,7 @@ void CalibrateAxis::handleVescStatus(const rex_interfaces::msg::VescStatus::Cons
 		return;
 	}
 	rclcpp::Time now = rclcpp::Clock().now();
-	mMotorPositions[msg->vesc_id] = {msg->pid_pos, now};
+	mMotorPositions[msg->vesc_id] = {static_cast<float>(msg->precise_pos), now};
 	mMotorVelocities[msg->vesc_id] = {msg->erpm, now};
 }
 

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -8,12 +8,24 @@ const std::string CALIBRATION_MAX_OFFSET_SHIFT = "calibration.max_offset_shift";
 
 const std::string CALIBRATION_OUTDATED_DURATION_S = "calibration.outdated_duration_s";
 const std::string CALIBRATION_SPEED_TIMEOUT_MS = "calibration.speed_timeout_ms";
+const std::string CALIBRATION_MESSAGE_SEND_PERIOD_MS = "calibration.message_send_period_ms";
+
+const std::string CALIBRATION_STOP_CONDITION = "calibration.stop_condition";
+const std::string CALIBRATION_STOP_TOLERANCE = "calibration.stop_tolerance";
 
 constexpr float NaN = std::numeric_limits<float>::quiet_NaN();
 
 CalibrateAxis::CalibrateAxis(const rclcpp::NodeOptions &options) : Node("calibrate_axis", options)
 {
 	const rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(256));
+
+	mMode = Mode::Nothing;
+	mCalibrationMotors = {
+		RosCanConstants::VescIds::front_left_stepper,
+		RosCanConstants::VescIds::front_right_stepper,
+		RosCanConstants::VescIds::rear_left_stepper,
+		RosCanConstants::VescIds::rear_right_stepper,
+	};
 
 	initParams();
 
@@ -29,19 +41,25 @@ CalibrateAxis::CalibrateAxis(const rclcpp::NodeOptions &options) : Node("calibra
 		RosCanConstants::RosTopics::mqtt_rover_status,
 		qos, std::bind(&CalibrateAxis::handleRoverStatus, this, std::placeholders::_1));
 
-	mCalibrationMotors = {
-		RosCanConstants::VescIds::front_left_stepper,
-		RosCanConstants::VescIds::front_right_stepper,
-		RosCanConstants::VescIds::rear_left_stepper,
-		RosCanConstants::VescIds::rear_right_stepper,
-	};
+	mFrameSender = this->create_timer(
+		std::chrono::milliseconds(mIntParams[CALIBRATION_MESSAGE_SEND_PERIOD_MS]),
+		[this]
+		{
+			if (!mLastRoverStatus || mLastRoverStatus->control_mode != rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP)
+				return;
+			if (mMode != Mode::Nothing)
+			{
+				mFrameToSend.header.stamp = this->get_clock()->now();
+				mCalibrationMotorCommandPub->publish(mFrameToSend);
+			}
+		});
 
 	initTimeoutTimers();
 
 	mOffset = NaN;
 	mCurrentMotorID = 0;
 
-	RCLCPP_DEBUG(this->get_logger(), "Calibration module started.");
+	RCLCPP_INFO(this->get_logger(), "Calibration module started.");
 };
 
 void CalibrateAxis::initParams()
@@ -51,7 +69,8 @@ void CalibrateAxis::initParams()
 		{CALIBRATION_POS_ACCELERATION, 3.0f},
 		{CALIBRATION_MAX_SPEED, 3.0f},
 		{CALIBRATION_MAX_OFFSET_SHIFT, 30.0f},
-		{CALIBRATION_OUTDATED_DURATION_S, 0.3f}};
+		{CALIBRATION_OUTDATED_DURATION_S, 0.3f},
+		{CALIBRATION_STOP_TOLERANCE, 0.5f}};
 	for (auto &[name, value] : mFloatParams)
 	{
 		this->declare_parameter(name, value);
@@ -59,7 +78,9 @@ void CalibrateAxis::initParams()
 	}
 
 	mIntParams = {
-		{CALIBRATION_SPEED_TIMEOUT_MS, 500}};
+		{CALIBRATION_SPEED_TIMEOUT_MS, 500},
+		{CALIBRATION_STOP_CONDITION, 3},
+		{CALIBRATION_MESSAGE_SEND_PERIOD_MS, 1000 / 50}};
 	for (auto &[name, value] : mIntParams)
 	{
 		this->declare_parameter(name, value);
@@ -95,9 +116,35 @@ void CalibrateAxis::handleVescStatus(const rex_interfaces::msg::VescStatus::Cons
 	{
 		return;
 	}
-	rclcpp::Time now = rclcpp::Clock().now();
+	rclcpp::Time now = this->get_clock()->now();
 	mMotorPositions[msg->vesc_id] = {static_cast<float>(msg->precise_pos), now};
 	mMotorVelocities[msg->vesc_id] = {msg->erpm, now};
+
+	if (msg->vesc_id != mCurrentMotorID)
+		return;
+
+	bool condition;
+	switch (mIntParams[CALIBRATION_STOP_CONDITION])
+	{
+	default:
+	case 1:
+		condition = msg->erpm == 0;
+		break;
+	case 2:
+		condition = std::abs(msg->precise_pos - mFrameToSend.set_pos_speed_loop_position) <= mFloatParams[CALIBRATION_STOP_TOLERANCE];
+		break;
+	case 3:
+		condition = msg->erpm == 0 && std::abs(msg->precise_pos - mFrameToSend.set_pos_speed_loop_position) <= mFloatParams[CALIBRATION_STOP_TOLERANCE];
+		break;
+	case 4:
+		condition = msg->erpm == 0 || std::abs(msg->precise_pos - mFrameToSend.set_pos_speed_loop_position) <= mFloatParams[CALIBRATION_STOP_TOLERANCE];
+		break;
+	}
+	if (mMode == Mode::SetPos && condition)
+	{
+		RCLCPP_INFO(this->get_logger(), "End of SetPos reached, holding...");
+		modeHold(mCurrentMotorID);
+	}
 }
 
 void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis::ConstSharedPtr &msg)
@@ -122,12 +169,21 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 		return;
 	}
 
-	// If motor is still moving, only STOP or CANCEL are fine
-	if (std::abs(mMotorVelocities[msg->vesc_id].erpm) > 0)
+	// If motor is moving by SetVelocity, only STOP, CANCEL and SET_VELOCITY are fine
+	// If motor is moving by Offset, only STOP and CANCEL are fine
+	if (mMode == Mode::SetVelocity)
+	{
+		if (msg->action_type != CalibrateMsg::ACTION_TYPE_SET_VELOCITY && msg->action_type != CalibrateMsg::ACTION_TYPE_STOP && msg->action_type != CalibrateMsg::ACTION_TYPE_CANCEL)
+		{
+			RCLCPP_INFO(this->get_logger(), "Calibration request rejected, the motor is still moving");
+			return;
+		}
+	}
+	else if (mMode == Mode::SetPos)
 	{
 		if (!(msg->action_type == CalibrateMsg::ACTION_TYPE_STOP || msg->action_type == CalibrateMsg::ACTION_TYPE_CANCEL))
 		{
-			RCLCPP_DEBUG(this->get_logger(), "Calibration request rejected, the motor is still moving");
+			RCLCPP_INFO(this->get_logger(), "Calibration request rejected, the motor is still moving");
 			return;
 		}
 	}
@@ -144,7 +200,10 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 	if (mCurrentMotorID != msg->vesc_id)
 	{
 		if (mCurrentMotorID)
+		{
 			stopMotor(mCurrentMotorID);
+			modeNothing();
+		}
 		mCurrentMotorID = msg->vesc_id;
 		mOffset = NaN;
 	}
@@ -156,30 +215,37 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 	switch (msg->action_type)
 	{
 	case CalibrateMsg::ACTION_TYPE_STOP:
+		RCLCPP_INFO(this->get_logger(), "Stop received for %#x", msg->vesc_id);
 		stopMotor(msg->vesc_id);
+		modeHold(msg->vesc_id);
 		break;
 
 	case CalibrateMsg::ACTION_TYPE_RETURN_TO_ORIGIN:
-		fr = frameSetPosition(msg->vesc_id, 0.0f);
+		RCLCPP_INFO(this->get_logger(), "Return to origin received for %#x", msg->vesc_id);
 		mOffset = 0.0;
-		mCalibrationMotorCommandPub->publish(fr);
+		modeSetPos(msg->vesc_id, 0.0f);
 		break;
 
 	case CalibrateMsg::ACTION_TYPE_CONFIRM:
+		RCLCPP_INFO(this->get_logger(), "Confirm received for %#x", msg->vesc_id);
 		stopMotor(msg->vesc_id);
 		fr = frameSetOrigin(msg->vesc_id);
 		mCalibrationMotorCommandPub->publish(fr);
 		mOffset = NaN;
 		mCurrentMotorID = 0;
+		modeNothing();
 		break;
 
 	case CalibrateMsg::ACTION_TYPE_CANCEL:
+		RCLCPP_INFO(this->get_logger(), "Cancel received for %#x", msg->vesc_id);
 		stopMotor(msg->vesc_id);
 		mOffset = NaN;
 		mCurrentMotorID = 0;
+		modeNothing();
 		break;
 
 	case CalibrateMsg::ACTION_TYPE_OFFSET:
+		RCLCPP_INFO(this->get_logger(), "Offset received for %#x", msg->vesc_id);
 		if (std::isnan(mOffset))
 		{
 			if (!isRecordedPositionValid(msg->vesc_id))
@@ -199,11 +265,12 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 		}
 
 		mOffset += offsetShift;
-		fr = frameSetPosition(msg->vesc_id, mOffset);
-		mCalibrationMotorCommandPub->publish(fr);
+
+		modeSetPos(msg->vesc_id, mOffset);
 		break;
 
 	case CalibrateMsg::ACTION_TYPE_SET_VELOCITY:
+		RCLCPP_INFO(this->get_logger(), "SetVelocity received for %#x", msg->vesc_id);
 		// Limit value
 		float velocity = msg->value;
 		if (std::abs(velocity) > mFloatParams[CALIBRATION_MAX_SPEED])
@@ -214,12 +281,21 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 
 		// Handle the stop timers
 		if (velocity == 0.0f)
-			cancelTimeout(msg->vesc_id);
+		{
+			// Only stop if motor was moving.
+			if (mMode == Mode::SetVelocity)
+			{
+				stopMotor(msg->vesc_id);
+				modeHold(msg->vesc_id);
+				cancelTimeout(msg->vesc_id);
+			}
+		}
 		else
+		{
+			modeSetVelocity(msg->vesc_id, velocity);
 			startTimeout(msg->vesc_id);
+		}
 
-		fr = frameSetVelocity(msg->vesc_id, velocity);
-		mCalibrationMotorCommandPub->publish(fr);
 		break;
 	}
 }
@@ -227,6 +303,43 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 void CalibrateAxis::handleRoverStatus(const rex_interfaces::msg::RoverStatus::ConstSharedPtr &msg)
 {
 	mLastRoverStatus = msg;
+}
+
+void CalibrateAxis::modeNothing()
+{
+	mFrameToSend = rex_interfaces::msg::VescMotorCommand();
+	mMode = Mode::Nothing;
+}
+
+void CalibrateAxis::modeSetPos(VESC_Id_t vescID, float pos)
+{
+	mFrameToSend = frameSetPosition(vescID, pos);
+	mMode = Mode::SetPos;
+}
+
+void CalibrateAxis::modeSetVelocity(VESC_Id_t vescID, float velocity)
+{
+	mFrameToSend = frameSetVelocity(vescID, velocity);
+	mMode = Mode::SetVelocity;
+}
+
+void CalibrateAxis::modeHold(VESC_Id_t vescID)
+{
+	if (isTimestampOutdated(mMotorPositions[vescID].receivedAt))
+	{
+		modeNothing();
+		RCLCPP_ERROR(this->get_logger(), "Tried to hold, but position is outdated");
+		return;
+	}
+
+	mFrameToSend = frameSetPosition(vescID, mMotorPositions[vescID].position);
+	mMode = Mode::Hold;
+}
+
+bool CalibrateAxis::isTimestampOutdated(rclcpp::Time stamp)
+{
+	rclcpp::Time now = this->get_clock()->now();
+	return (now - stamp).seconds() > mFloatParams[CALIBRATION_OUTDATED_DURATION_S];
 }
 
 bool CalibrateAxis::isRecordedVelocityValid(VESC_Id_t vescID)
@@ -238,8 +351,8 @@ bool CalibrateAxis::isRecordedVelocityValid(VESC_Id_t vescID)
 		RCLCPP_WARN(this->get_logger(), "Calibration failed, no recorded velocity for motor with ID %#x", vescID);
 		return false;
 	}
-	rclcpp::Time now = rclcpp::Clock().now();
-	if ((now - mMotorVelocities[vescID].receivedAt).seconds() > mFloatParams[CALIBRATION_OUTDATED_DURATION_S])
+
+	if (isTimestampOutdated(mMotorVelocities[vescID].receivedAt))
 	{
 		RCLCPP_WARN(this->get_logger(), "Calibration failed, recorded velocity for motor with id %#x is outdated", vescID);
 		return false;
@@ -257,8 +370,7 @@ bool CalibrateAxis::isRecordedPositionValid(VESC_Id_t vescID)
 		return false;
 	}
 
-	rclcpp::Time now = rclcpp::Clock().now();
-	if ((now - mMotorPositions[vescID].receivedAt).seconds() > mFloatParams[CALIBRATION_OUTDATED_DURATION_S])
+	if (isTimestampOutdated(mMotorPositions[vescID].receivedAt))
 	{
 		RCLCPP_WARN(this->get_logger(), "Calibration failed, recorded position for motor with id %#x is outdated", vescID);
 		return false;
@@ -274,7 +386,12 @@ void CalibrateAxis::initTimeoutTimers()
 			std::chrono::milliseconds(mIntParams[CALIBRATION_SPEED_TIMEOUT_MS]),
 			[this, id]()
 			{
+				if (mMode != Mode::SetVelocity)
+					RCLCPP_ERROR(this->get_logger(), "Mode is not SetVelocity, yet velocity timeout runs anyway");
 				stopMotor(id);
+				if (mCurrentMotorID != id)
+					RCLCPP_ERROR(this->get_logger(), "Timeout ran on non-current motor. Assumption wrong, shouldn't hold.");
+				modeHold(id);
 				// cancelTimeout(vescID); // Redundant as stopMotor already calls cancelTimeout()
 			});
 		mSpeedStopTimers[id]->cancel();
@@ -283,11 +400,21 @@ void CalibrateAxis::initTimeoutTimers()
 
 void CalibrateAxis::startTimeout(VESC_Id_t vescID)
 {
+	if (!mSpeedStopTimers.count(vescID))
+	{
+		RCLCPP_ERROR(this->get_logger(), "Tried to start timer of invalid motor: %#x", vescID);
+		return;
+	}
 	mSpeedStopTimers[vescID]->reset();
 }
 
 void CalibrateAxis::cancelTimeout(VESC_Id_t vescID)
 {
+	if (!mSpeedStopTimers.count(vescID))
+	{
+		RCLCPP_ERROR(this->get_logger(), "Tried to cancel timer of invalid motor: %#x", vescID);
+		return;
+	}
 	mSpeedStopTimers[vescID]->cancel();
 }
 
@@ -307,7 +434,7 @@ rex_interfaces::msg::VescMotorCommand CalibrateAxis::frameStop(VESC_Id_t vescID)
 	msg.command_id = VESC_COMMAND_SET_CURRENT;
 	msg.set_value = 0.0f;
 
-	msg.header.stamp = rclcpp::Clock().now();
+	msg.header.stamp = this->get_clock()->now();
 
 	return msg;
 }
@@ -320,7 +447,7 @@ rex_interfaces::msg::VescMotorCommand CalibrateAxis::frameSetOrigin(VESC_Id_t ve
 	msg.command_id = VESC_COMMAND_SET_ORIGIN;
 	msg.set_origin_data = 0.0f;
 
-	msg.header.stamp = rclcpp::Clock().now();
+	msg.header.stamp = this->get_clock()->now();
 
 	return msg;
 }
@@ -335,7 +462,7 @@ rex_interfaces::msg::VescMotorCommand CalibrateAxis::frameSetPosition(VESC_Id_t 
 	msg.set_pos_speed_loop_speed = mFloatParams[CALIBRATION_POS_SPEED];
 	msg.set_pos_speed_loop_acceleration = mFloatParams[CALIBRATION_POS_ACCELERATION];
 
-	msg.header.stamp = rclcpp::Clock().now();
+	msg.header.stamp = this->get_clock()->now();
 
 	return msg;
 }
@@ -348,7 +475,7 @@ rex_interfaces::msg::VescMotorCommand CalibrateAxis::frameSetVelocity(VESC_Id_t 
 	msg.command_id = VESC_COMMAND_SET_RPM;
 	msg.set_value = velocity;
 
-	msg.header.stamp = rclcpp::Clock().now();
+	msg.header.stamp = this->get_clock()->now();
 
 	return msg;
 }

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -124,7 +124,7 @@ void CalibrateAxis::handleVescStatus(const rex_interfaces::msg::VescStatus::Cons
 	{
 		float targetPos = getTargetPosFromSetPosFrame(mFrameToSend);
 		float newDistance = std::abs(msg->precise_pos - targetPos);
-		float error = 0.5;
+		float error = 5;
 		if (newDistance > mSetPosDistanceToTarget + error)
 		{
 			// This should never happen. It means that the motor moved away from the target position or passed it,

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -17,9 +17,6 @@ CalibrateAxis::CalibrateAxis(const rclcpp::NodeOptions &options) : Node("calibra
 {
 	const rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(256));
 
-	modeNothing();
-	mHoldScheduled = false;
-
 	mCalibrationMotors = {
 		RosCanConstants::VescIds::front_left_stepper,
 		RosCanConstants::VescIds::front_right_stepper,
@@ -53,6 +50,9 @@ CalibrateAxis::CalibrateAxis(const rclcpp::NodeOptions &options) : Node("calibra
 		std::bind(&CalibrateAxis::timeoutTimerTick, this));
 	mVelocityTimeoutTimer->cancel();
 
+	modeNothing();
+	mHoldScheduled = false;
+
 	RCLCPP_INFO(this->get_logger(), "Calibration module started.");
 };
 
@@ -84,22 +84,22 @@ void CalibrateAxis::initParams()
 		mIntParams[name] = this->get_parameter(name).as_int();
 	}
 
-	mParamCallbackHandle = this->add_post_set_parameters_callback(
-		[this](const std::vector<rclcpp::Parameter> &params)
-		{
-			for (const auto &param : params)
-			{
-				const std::string name = param.get_name();
-				if (mFloatParams.count(name))
-				{
-					mFloatParams[name] = param.as_double();
-				}
-				else if (mIntParams.count(name))
-				{
-					mIntParams[name] = param.as_int();
-				}
-			}
-		});
+	// mParamCallbackHandle = this->add_post_set_parameters_callback(
+	// 	[this](const std::vector<rclcpp::Parameter> &params)
+	// 	{
+	// 		for (const auto &param : params)
+	// 		{
+	// 			const std::string name = param.get_name();
+	// 			if (mFloatParams.count(name))
+	// 			{
+	// 				mFloatParams[name] = param.as_double();
+	// 			}
+	// 			else if (mIntParams.count(name))
+	// 			{
+	// 				mIntParams[name] = param.as_int();
+	// 			}
+	// 		}
+	// 	});
 }
 
 // ######################### MSG HANDLERS #########################
@@ -214,14 +214,14 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 	// --------------------
 
 	rex_interfaces::msg::VescMotorCommand fr;
-	// float offsetShift;
+	float offsetShift;
 	switch (msg->action_type)
 	{
 	case CalibrateMsg::ACTION_TYPE_STOP:
 		stopMotor(msg->vesc_id);
 		modeNothing(); // Clear the SetPos frame so that Hold doesn't use it (for safety reasons)
 		if (mIntParams[CALIBRATION_USE_SCHEDULE_HOLD])
-			mHoldScheduled = true;
+			scheduleHold(msg->vesc_id);
 		else
 			modeHold(msg->vesc_id);
 		break;
@@ -266,7 +266,7 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 		}
 
 		// Limit value
-		float offsetShift = msg->value;
+		offsetShift = msg->value;
 		if (std::abs(offsetShift) > mFloatParams[CALIBRATION_MAX_OFFSET_SHIFT])
 		{
 			RCLCPP_WARN(this->get_logger(), "Calibration: can't move by offset that much at a time! (tried %f, max %f)",
@@ -320,7 +320,7 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 				if (mIntParams[CALIBRATION_USE_SCHEDULE_HOLD])
 				{
 					modeNothing();
-					mHoldScheduled = true;
+					scheduleHold(msg->vesc_id);
 				}
 				else
 					modeHold(msg->vesc_id);
@@ -372,6 +372,7 @@ void CalibrateAxis::modeNothing()
 	mFrameToSend = rex_interfaces::msg::VescMotorCommand();
 	mMode = Mode::Nothing;
 	mCurrentMotorID = 0;
+	cancelTimeout();
 }
 
 void CalibrateAxis::modeSetPos(VESC_Id_t vescID, float pos)
@@ -404,6 +405,7 @@ void CalibrateAxis::modeHold(VESC_Id_t vescID)
 	{
 		RCLCPP_ERROR(this->get_logger(), "Tried to hold, but position is outdated");
 		modeNothing();
+		return;
 	}
 	else
 	{
@@ -428,20 +430,29 @@ void CalibrateAxis::cancelTimeout()
 
 void CalibrateAxis::timeoutTimerTick()
 {
+	VESC_Id_t vescID = mCurrentMotorID;
+	if (!vescID || !calibrationMotorsContains(vescID))
+	{
+		RCLCPP_ERROR(this->get_logger(), "Timeout handler: Invalid motor ID");
+		cancelTimeout();
+		return;
+	}
 	if (mMode != Mode::SetVelocity)
 	{
 		RCLCPP_ERROR(this->get_logger(), "Error: timeout timer wasn't cancelled correctly!");
+		cancelTimeout();
+		return;
 	}
-	RCLCPP_INFO(this->get_logger(), "Motor [%d] stopped by timeout", mCurrentMotorID);
-	// stopMotor cancels the timer
-	stopMotor(mCurrentMotorID);
+	RCLCPP_INFO(this->get_logger(), "Motor [%d] stopped by timeout", vescID);
+	stopMotor(vescID);
 	if (mIntParams[CALIBRATION_USE_SCHEDULE_HOLD])
 	{
 		modeNothing();
-		mHoldScheduled = true;
+		scheduleHold(vescID);
 	}
 	else
-		modeHold(mCurrentMotorID);
+		modeHold(vescID);
+	cancelTimeout();
 }
 
 void CalibrateAxis::stopMotor(VESC_Id_t vescID)
@@ -565,6 +576,12 @@ bool CalibrateAxis::isRecordedStatusValid(VESC_Id_t vescID)
 		return false;
 	}
 	return true;
+}
+
+void CalibrateAxis::scheduleHold(VESC_Id_t vescID)
+{
+	mHoldScheduled = true;
+	mCurrentMotorID = vescID;
 }
 
 template <typename T>

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -104,7 +104,7 @@ void CalibrateAxis::initParams()
 void CalibrateAxis::handleVescStatus(const rex_interfaces::msg::VescStatus::ConstSharedPtr &msg)
 {
 	// RCLCPP_INFO(this->get_logger(), "%d precise %lf pid %f", msg->vesc_id, msg->precise_pos, msg->pid_pos);
-	if (!calibrationMotorsContains(msg->vesc_id))
+	if (!isCalibrationAllowedForMotor(msg->vesc_id))
 	{
 		// Only interested in calibratable motors.
 		return;
@@ -116,6 +116,39 @@ void CalibrateAxis::handleVescStatus(const rex_interfaces::msg::VescStatus::Cons
 
 	if (msg->vesc_id != mCurrentMotorID)
 		return;
+
+	// SetPos out-of-bounds emergency check
+	if (mMode == Mode::SetPos &&
+		!std::isnan(mSetPosStartingPosition) &&
+		std::abs(mSetPosStartingPosition - msg->precise_pos) > mFloatParams[CALIBRATION_MAX_OFFSET_SHIFT] + 5)
+	{
+		// This should never happen. It means that the motor moved away from the target position or passed it,
+		// and will never stop. This is a hardware problem, the motor will be locked
+		RCLCPP_FATAL(this->get_logger(),
+					 "Motor moved away from the target position or passed it while in SetPos mode. This is a hardware failure."
+					 "The motor will be locked until CalibrateAxis restart.");
+		stopMotor(msg->vesc_id);
+		modeNothing();
+		lockMotor(msg->vesc_id);
+		return;
+	}
+
+	// Hold drift emergency check
+	if (mMode == Mode::Hold)
+	{
+		// Scale related to https://github.com/AlvaroBajceps/libVescCan/issues/10
+		float holdTarget = mFrameToSend.set_value * 100.0;
+		if (std::abs(holdTarget - msg->precise_pos) > 2.0) // Arbitrary threshold
+		{
+			RCLCPP_FATAL(this->get_logger(),
+						 "Drift detected during Hold mode. This is likely a hardware failure."
+						 "The motor will be locked until CalibrateAxis restart.");
+			stopMotor(msg->vesc_id);
+			modeNothing();
+			lockMotor(msg->vesc_id);
+			return;
+		}
+	}
 
 	// --- Mode end-conditions below
 
@@ -137,7 +170,7 @@ void CalibrateAxis::handleVescStatus(const rex_interfaces::msg::VescStatus::Cons
 		cancelTimeout();
 		// Snap to max shift
 		// +1 so that SetVelocity frames in the outer direction will still be rejected
-		modeSetPos(msg->vesc_id, signum(msg->precise_pos) * (mFloatParams[CALIBRATION_MAX_VELOCITY_SHIFT] + 1));
+		modeSetPos(msg->vesc_id, signum(msg->precise_pos) * (mFloatParams[CALIBRATION_MAX_VELOCITY_SHIFT] + 1), false);
 	}
 }
 
@@ -156,7 +189,7 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 		return;
 	}
 
-	if (!calibrationMotorsContains(msg->vesc_id))
+	if (!isCalibrationAllowedForMotor(msg->vesc_id))
 	{
 		RCLCPP_ERROR(this->get_logger(), "Attempted to calibrate motor with invalid VESC ID: %#x", msg->vesc_id);
 		return;
@@ -207,7 +240,7 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 		break;
 
 	case CalibrateMsg::ACTION_TYPE_RETURN_TO_ORIGIN:
-		modeSetPos(msg->vesc_id, 0.0f);
+		modeSetPos(msg->vesc_id, 0.0f, true);
 		break;
 
 	case CalibrateMsg::ACTION_TYPE_CONFIRM:
@@ -255,7 +288,7 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 			offsetShift = std::clamp(offsetShift, -mFloatParams[CALIBRATION_MAX_OFFSET_SHIFT], mFloatParams[CALIBRATION_MAX_OFFSET_SHIFT]);
 		}
 
-		modeSetPos(msg->vesc_id, startingPosition + offsetShift);
+		modeSetPos(msg->vesc_id, startingPosition + offsetShift, false);
 		break;
 
 	case CalibrateMsg::ACTION_TYPE_SET_VELOCITY:
@@ -356,8 +389,19 @@ void CalibrateAxis::modeNothing()
 	cancelTimeout();
 }
 
-void CalibrateAxis::modeSetPos(VESC_Id_t vescID, float pos)
+void CalibrateAxis::modeSetPos(VESC_Id_t vescID, float pos, bool dontSaveStartingPos)
 {
+	if (!isRecordedStatusValid(vescID))
+	{
+		RCLCPP_ERROR(this->get_logger(), "modeSetPos called even though there is no recent status for the motor");
+		stopMotor(vescID);
+		modeNothing();
+		return;
+	}
+	if (!dontSaveStartingPos)
+		mSetPosStartingPosition = mMotorStatuses[vescID].position;
+	else
+		mSetPosStartingPosition = std::numeric_limits<float>::quiet_NaN();
 	RCLCPP_INFO(this->get_logger(), "MODE SetPos [%d]: %f", vescID, pos);
 	mFrameToSend = frameSetPosition(vescID, pos);
 	mMode = Mode::SetPos;
@@ -409,7 +453,7 @@ void CalibrateAxis::cancelTimeout()
 void CalibrateAxis::timeoutTimerTick()
 {
 	VESC_Id_t vescID = mCurrentMotorID;
-	if (!vescID || !calibrationMotorsContains(vescID))
+	if (!vescID || !isCalibrationAllowedForMotor(vescID))
 	{
 		RCLCPP_ERROR(this->get_logger(), "Timeout handler: Invalid motor ID");
 		cancelTimeout();
@@ -504,7 +548,7 @@ void CalibrateAxis::sendFrame()
 
 // ######################### UTILITY #########################
 
-bool CalibrateAxis::calibrationMotorsContains(VESC_Id_t vescID)
+bool CalibrateAxis::isCalibrationAllowedForMotor(VESC_Id_t vescID)
 {
 	// Check if the supplied ID is in the list of motors allowed for calibration.
 	return std::find(mCalibrationMotors.begin(), mCalibrationMotors.end(), vescID) != mCalibrationMotors.end();
@@ -558,4 +602,14 @@ int signum(T val)
 	if (val < 0)
 		return -1;
 	return 0;
+}
+
+void CalibrateAxis::lockMotor(VESC_Id_t vescID)
+{
+	// Remove the motor from mCalibrationMotors, effectively locking it.
+	auto it = std::find(mCalibrationMotors.begin(), mCalibrationMotors.end(), vescID);
+	if (it != mCalibrationMotors.end())
+	{
+		mCalibrationMotors.erase(it);
+	}
 }

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -8,7 +8,6 @@ const std::string CALIBRATION_OUTDATED_DURATION_S = "calibration.outdated_durati
 const std::string CALIBRATION_SPEED_TIMEOUT_MS = "calibration.speed_timeout_ms";
 const std::string CALIBRATION_MESSAGE_SEND_PERIOD_MS = "calibration.message_send_period_ms";
 
-const std::string CALIBRATION_STOP_CONDITION = "calibration.stop_condition";
 const std::string CALIBRATION_STOP_TOLERANCE = "calibration.stop_tolerance";
 
 const std::string CALIBRATION_LOG_SETPOS_DIFF = "calibration.log_setpos_diff";
@@ -106,7 +105,6 @@ void CalibrateAxis::initParams()
 
 	mIntParams = {
 		{CALIBRATION_SPEED_TIMEOUT_MS, 500},
-		{CALIBRATION_STOP_CONDITION, 3},
 		{CALIBRATION_MESSAGE_SEND_PERIOD_MS, 1000 / 50},
 		{CALIBRATION_LOG_SETPOS_DIFF, 0},
 		{CALIBRATION_USE_SCHEDULE_HOLD, 1}};
@@ -437,22 +435,7 @@ bool CalibrateAxis::checkSetPosEndCondition(const rex_interfaces::msg::VescStatu
 			this->get_logger(), "Target is %f, current is %f, diff is %f, tolerance is %f",
 			targetValue, msg->precise_pos, std::abs(targetValue - msg->precise_pos), mFloatParams[CALIBRATION_STOP_TOLERANCE]);
 
-	switch (mIntParams[CALIBRATION_STOP_CONDITION])
-	{
-	default:
-	case 1:
-		return msg->erpm == 0;
-		break;
-	case 2:
-		return std::abs(msg->precise_pos - targetValue) <= mFloatParams[CALIBRATION_STOP_TOLERANCE];
-		break;
-	case 3:
-		return msg->erpm == 0 && std::abs(msg->precise_pos - targetValue) <= mFloatParams[CALIBRATION_STOP_TOLERANCE];
-		break;
-	case 4:
-		return msg->erpm == 0 || std::abs(msg->precise_pos - targetValue) <= mFloatParams[CALIBRATION_STOP_TOLERANCE];
-		break;
-	}
+	return msg->erpm == 0 && std::abs(msg->precise_pos - targetValue) <= mFloatParams[CALIBRATION_STOP_TOLERANCE];
 }
 
 bool CalibrateAxis::isTimestampOutdated(rclcpp::Time stamp)

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -1,15 +1,15 @@
 #include "calibration_manager/CalibrateAxis.hpp"
 
+// Float
 const std::string CALIBRATION_MAX_SPEED = "max_speed";
 const std::string CALIBRATION_MAX_OFFSET_SHIFT = "max_offset_shift";
 const std::string CALIBRATION_MAX_VELOCITY_SHIFT = "max_velocity_shift";
-
 const std::string CALIBRATION_OUTDATED_DURATION_S = "outdated_duration_s";
-const std::string CALIBRATION_SPEED_TIMEOUT_MS = "speed_timeout_ms";
 const std::string CALIBRATION_MESSAGE_SEND_PERIOD_MS = "message_send_period_ms";
 
+// Int
+const std::string CALIBRATION_SPEED_TIMEOUT_MS = "speed_timeout_ms";
 const std::string CALIBRATION_STOP_TOLERANCE = "stop_tolerance";
-
 const std::string CALIBRATION_LOG_SETPOS_DIFF = "log_setpos_diff";
 
 CalibrateAxis::CalibrateAxis(const rclcpp::NodeOptions &options) : Node("calibrate_axis", options)
@@ -60,7 +60,7 @@ void CalibrateAxis::initParams()
 	// Also registers a callback for dynamic param changing
 
 	mFloatParams = {
-		{CALIBRATION_MAX_SPEED, 3.0f},
+		{CALIBRATION_MAX_SPEED, 5000.0f},
 		{CALIBRATION_MAX_OFFSET_SHIFT, 30.0f},
 		{CALIBRATION_MAX_VELOCITY_SHIFT, 30.0f},
 		{CALIBRATION_OUTDATED_DURATION_S, 0.3f},
@@ -81,6 +81,7 @@ void CalibrateAxis::initParams()
 		mIntParams[name] = this->get_parameter(name).as_int();
 	}
 
+	// Dynamic param updating
 	// mParamCallbackHandle = this->add_post_set_parameters_callback(
 	// 	[this](const std::vector<rclcpp::Parameter> &params)
 	// 	{
@@ -112,33 +113,38 @@ void CalibrateAxis::handleVescStatus(const rex_interfaces::msg::VescStatus::Cons
 	rclcpp::Time now = this->get_clock()->now();
 	mMotorStatuses[msg->vesc_id] = {static_cast<float>(msg->precise_pos), msg->erpm, now};
 
-	// Below only applies to the currently-calibrated motor.
-
 	if (msg->vesc_id != mCurrentMotorID)
 		return;
 
-	// SetPos out-of-bounds emergency check
-	if (mMode == Mode::SetPos &&
-		!std::isnan(mSetPosStartingPosition) &&
-		std::abs(mSetPosStartingPosition - msg->precise_pos) > mFloatParams[CALIBRATION_MAX_OFFSET_SHIFT] + 5)
+	// --------------------
+	// Below only applies to the currently-calibrated motor.
+
+	// SetPos wrong behavior emergency check
+	if (mMode == Mode::SetPos)
 	{
-		// This should never happen. It means that the motor moved away from the target position or passed it,
-		// and will never stop. This is a hardware problem, the motor will be locked
-		RCLCPP_FATAL(this->get_logger(),
-					 "Motor moved away from the target position or passed it while in SetPos mode. This is a hardware failure."
-					 "The motor will be locked until CalibrateAxis restart.");
-		stopMotor(msg->vesc_id);
-		modeNothing();
-		lockMotor(msg->vesc_id);
-		return;
+		float targetPos = getTargetPosFromSetPosFrame(mFrameToSend);
+		float newDistance = std::abs(msg->precise_pos - targetPos);
+		float error = 0.5;
+		if (newDistance > mSetPosDistanceToTarget + error)
+		{
+			// This should never happen. It means that the motor moved away from the target position or passed it,
+			// and will never stop. This is a hardware problem, the motor will be locked
+			RCLCPP_FATAL(this->get_logger(),
+						 "Motor moved away from the target position or passed it while in SetPos mode. This is a hardware failure."
+						 "The motor will be locked until CalibrateAxis restart.");
+			stopMotor(msg->vesc_id);
+			modeNothing();
+			lockMotor(msg->vesc_id);
+			return;
+		}
+		mSetPosDistanceToTarget = newDistance;
 	}
 
 	// Hold drift emergency check
 	if (mMode == Mode::Hold)
 	{
-		// Scale related to https://github.com/AlvaroBajceps/libVescCan/issues/10
-		float holdTarget = mFrameToSend.set_value * 100.0;
-		if (std::abs(holdTarget - msg->precise_pos) > 2.0) // Arbitrary threshold
+		float holdTarget = getTargetPosFromSetPosFrame(mFrameToSend);
+		if (std::abs(holdTarget - msg->precise_pos) > 5.0) // Arbitrary threshold
 		{
 			RCLCPP_FATAL(this->get_logger(),
 						 "Drift detected during Hold mode. This is likely a hardware failure."
@@ -170,7 +176,7 @@ void CalibrateAxis::handleVescStatus(const rex_interfaces::msg::VescStatus::Cons
 		cancelTimeout();
 		// Snap to max shift
 		// +1 so that SetVelocity frames in the outer direction will still be rejected
-		modeSetPos(msg->vesc_id, signum(msg->precise_pos) * (mFloatParams[CALIBRATION_MAX_VELOCITY_SHIFT] + 1), false);
+		modeSetPos(msg->vesc_id, signum(msg->precise_pos) * (mFloatParams[CALIBRATION_MAX_VELOCITY_SHIFT] + 1));
 	}
 }
 
@@ -240,7 +246,7 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 		break;
 
 	case CalibrateMsg::ACTION_TYPE_RETURN_TO_ORIGIN:
-		modeSetPos(msg->vesc_id, 0.0f, true);
+		modeSetPos(msg->vesc_id, 0.0f);
 		break;
 
 	case CalibrateMsg::ACTION_TYPE_CONFIRM:
@@ -264,8 +270,7 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 		case Mode::SetPos:
 		case Mode::Hold:
 			// Continue to offset based on previous position.
-			// Scale related to https://github.com/AlvaroBajceps/libVescCan/issues/10
-			startingPosition = mFrameToSend.set_value * 100.0;
+			startingPosition = getTargetPosFromSetPosFrame(mFrameToSend);
 			break;
 		default:
 			if (!isRecordedStatusValid(msg->vesc_id))
@@ -288,7 +293,7 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 			offsetShift = std::clamp(offsetShift, -mFloatParams[CALIBRATION_MAX_OFFSET_SHIFT], mFloatParams[CALIBRATION_MAX_OFFSET_SHIFT]);
 		}
 
-		modeSetPos(msg->vesc_id, startingPosition + offsetShift, false);
+		modeSetPos(msg->vesc_id, startingPosition + offsetShift);
 		break;
 
 	case CalibrateMsg::ACTION_TYPE_SET_VELOCITY:
@@ -367,10 +372,9 @@ void CalibrateAxis::handleRoverStatus(const rex_interfaces::msg::RoverStatus::Co
 void CalibrateAxis::handleBatteryInfo(const rex_interfaces::msg::BatteryInfo::ConstSharedPtr &msg)
 {
 	// Black mushroom pressed
-	if (msg->hotswap_status & rex_interfaces::msg::BatteryInfo::DRIVE_STOP)
+	if (isBlackMushroomPressed(msg))
 	{
-		if (!mLastBatteryInfo ||
-			!(mLastBatteryInfo->hotswap_status & rex_interfaces::msg::BatteryInfo::DRIVE_STOP))
+		if (!mLastBatteryInfo || !isBlackMushroomPressed(mLastBatteryInfo))
 		{
 			modeNothing();
 		}
@@ -382,14 +386,14 @@ void CalibrateAxis::handleBatteryInfo(const rex_interfaces::msg::BatteryInfo::Co
 
 void CalibrateAxis::modeNothing()
 {
-	RCLCPP_INFO(this->get_logger(), "MODE Nothing");
 	mFrameToSend = rex_interfaces::msg::VescMotorCommand();
 	mMode = Mode::Nothing;
 	mCurrentMotorID = 0;
 	cancelTimeout();
+	RCLCPP_INFO(this->get_logger(), "MODE Nothing");
 }
 
-void CalibrateAxis::modeSetPos(VESC_Id_t vescID, float pos, bool dontSaveStartingPos)
+void CalibrateAxis::modeSetPos(VESC_Id_t vescID, float pos)
 {
 	if (!isRecordedStatusValid(vescID))
 	{
@@ -398,22 +402,19 @@ void CalibrateAxis::modeSetPos(VESC_Id_t vescID, float pos, bool dontSaveStartin
 		modeNothing();
 		return;
 	}
-	if (!dontSaveStartingPos)
-		mSetPosStartingPosition = mMotorStatuses[vescID].position;
-	else
-		mSetPosStartingPosition = std::numeric_limits<float>::quiet_NaN();
-	RCLCPP_INFO(this->get_logger(), "MODE SetPos [%d]: %f", vescID, pos);
+	mSetPosDistanceToTarget = std::abs(mMotorStatuses[vescID].position - pos);
 	mFrameToSend = frameSetPosition(vescID, pos);
 	mMode = Mode::SetPos;
 	mCurrentMotorID = vescID;
+	RCLCPP_INFO(this->get_logger(), "MODE SetPos [%d]: %f", vescID, pos);
 }
 
 void CalibrateAxis::modeSetVelocity(VESC_Id_t vescID, float velocity)
 {
-	RCLCPP_INFO(this->get_logger(), "MODE SetVelocity [%d]: %f", vescID, velocity);
 	mFrameToSend = frameSetVelocity(vescID, velocity);
 	mMode = Mode::SetVelocity;
 	mCurrentMotorID = vescID;
+	RCLCPP_INFO(this->get_logger(), "MODE SetVelocity [%d]: %f", vescID, velocity);
 }
 
 void CalibrateAxis::modeHold(VESC_Id_t vescID)
@@ -434,8 +435,8 @@ void CalibrateAxis::modeHold(VESC_Id_t vescID)
 		modeNothing();
 		return;
 	}
-	RCLCPP_INFO(this->get_logger(), "MODE Hold [%d]: %f", vescID, mFrameToSend.set_value * 100.0);
 	mCurrentMotorID = vescID;
+	RCLCPP_INFO(this->get_logger(), "MODE Hold [%d]: %f", vescID, mFrameToSend.set_value * 100.0);
 }
 
 // ######################### TIMER-RELATED #########################
@@ -537,7 +538,9 @@ rex_interfaces::msg::VescMotorCommand CalibrateAxis::frameSetVelocity(VESC_Id_t 
 
 void CalibrateAxis::sendFrame()
 {
-	if (!mLastRoverStatus || mLastRoverStatus->control_mode != rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP)
+	if (
+		!mLastRoverStatus || mLastRoverStatus->control_mode != rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP ||
+		!mLastBatteryInfo || isBlackMushroomPressed(mLastBatteryInfo))
 		return;
 	if (mMode != Mode::Nothing)
 	{
@@ -559,10 +562,12 @@ bool CalibrateAxis::checkSetPosEndCondition(const rex_interfaces::msg::VescStatu
 	// Checks if SetPos mode is ready to finished (wheel is at target position)
 	// Only run during Mode::SetPos!
 	if (mMode != Mode::SetPos)
+	{
+		RCLCPP_ERROR(this->get_logger(), "Checked SetPos end condition while not in SetPos!");
 		return false;
+	}
 
-	// Scale related to https://github.com/AlvaroBajceps/libVescCan/issues/10
-	float targetValue = mFrameToSend.set_value * 100.0;
+	float targetValue = getTargetPosFromSetPosFrame(mFrameToSend);
 
 	if (mIntParams[CALIBRATION_LOG_SETPOS_DIFF])
 		RCLCPP_INFO(
@@ -612,4 +617,19 @@ void CalibrateAxis::lockMotor(VESC_Id_t vescID)
 	{
 		mCalibrationMotors.erase(it);
 	}
+}
+
+float CalibrateAxis::getTargetPosFromSetPosFrame(rex_interfaces::msg::VescMotorCommand msg)
+{
+	if (msg.command_id != rex_interfaces::msg::VescMotorCommand::CMD_SET_POS)
+	{
+		RCLCPP_FATAL(this->get_logger(), "Tried to read the target position from a non-Set_Pos frame.");
+	}
+	// Scale related to https://github.com/AlvaroBajceps/libVescCan/issues/10
+	return msg.set_value * 100.0;
+}
+
+bool CalibrateAxis::isBlackMushroomPressed(const rex_interfaces::msg::BatteryInfo::ConstSharedPtr &msg)
+{
+	return msg->hotswap_status & rex_interfaces::msg::BatteryInfo::DRIVE_STOP;
 }

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -28,6 +28,7 @@ CalibrateAxis::CalibrateAxis(const rclcpp::NodeOptions &options) : Node("calibra
 	const rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(256));
 
 	modeNothing();
+	mHoldScheduled = false;
 
 	mCalibrationMotors = {
 		RosCanConstants::VescIds::front_left_stepper,
@@ -52,45 +53,21 @@ CalibrateAxis::CalibrateAxis(const rclcpp::NodeOptions &options) : Node("calibra
 
 	mFrameSender = this->create_timer(
 		std::chrono::milliseconds(mIntParams[CALIBRATION_MESSAGE_SEND_PERIOD_MS]),
-		[this]
-		{
-			if (!mLastRoverStatus || mLastRoverStatus->control_mode != rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP)
-				return;
-			if (mMode != Mode::Nothing)
-			{
-				mFrameToSend.header.stamp = this->get_clock()->now();
-				mCalibrationMotorCommandPub->publish(mFrameToSend);
-			}
-		});
+		std::bind(&CalibrateAxis::sendFrame, this));
 
 	mVelocityTimeoutTimer = this->create_timer(
 		std::chrono::milliseconds(mIntParams[CALIBRATION_SPEED_TIMEOUT_MS]),
-		[this]
-		{
-			if (mMode != Mode::SetVelocity)
-			{
-				RCLCPP_ERROR(this->get_logger(), "Error: timeout timer wasn't cancelled correctly!");
-			}
-			RCLCPP_INFO(this->get_logger(), "Motor [%d] stopped by timeout", mCurrentMotorID);
-			stopMotor(mCurrentMotorID);
-			if (mIntParams[CALIBRATION_USE_SCHEDULE_HOLD])
-			{
-				modeNothing();
-				mScheduleHold = true;
-			}
-			else
-				modeHold(mCurrentMotorID);
-			// stopMotor cancels the timer
-		});
+		std::bind(&CalibrateAxis::timeoutTimerTick, this));
 	mVelocityTimeoutTimer->cancel();
-
-	mScheduleHold = false;
 
 	RCLCPP_INFO(this->get_logger(), "Calibration module started.");
 };
 
 void CalibrateAxis::initParams()
 {
+	// Loads node parameters from args, launch files etc.
+	// Also registers a callback for dynamic param changing
+
 	mFloatParams = {
 		{CALIBRATION_MAX_SPEED, 3.0f},
 		{CALIBRATION_MAX_OFFSET_SHIFT, 30.0f},
@@ -132,29 +109,26 @@ void CalibrateAxis::initParams()
 		});
 }
 
-bool CalibrateAxis::calibrationMotorsContains(VESC_Id_t vescID)
-{
-	return std::find(mCalibrationMotors.begin(), mCalibrationMotors.end(), vescID) != mCalibrationMotors.end();
-}
-
+// ######################### MSG HANDLERS #########################
 void CalibrateAxis::handleVescStatus(const rex_interfaces::msg::VescStatus::ConstSharedPtr &msg)
 {
 	// RCLCPP_INFO(this->get_logger(), "%d precise %lf pid %f", msg->vesc_id, msg->precise_pos, msg->pid_pos);
 	if (!calibrationMotorsContains(msg->vesc_id))
 	{
+		// Only interested in calibratable motors.
 		return;
 	}
 	rclcpp::Time now = this->get_clock()->now();
 	mMotorStatuses[msg->vesc_id] = {static_cast<float>(msg->precise_pos), msg->erpm, now};
 
-	// --- Mode end/stop conditions below
+	// Below only applies to the currently-calibrated motor.
 
 	if (msg->vesc_id != mCurrentMotorID)
 		return;
 
-	if (mScheduleHold)
+	if (mHoldScheduled)
 	{
-		if (mMode != Mode::Nothing)
+		if (mMode == Mode::Nothing)
 		{
 			RCLCPP_ERROR(this->get_logger(), "Hold schedule wasn't cancelled correctly! Any mode changes should cancel it.");
 		}
@@ -166,6 +140,8 @@ void CalibrateAxis::handleVescStatus(const rex_interfaces::msg::VescStatus::Cons
 		}
 	}
 
+	// --- Mode end-conditions below
+
 	if (mMode == Mode::SetPos && checkSetPosEndCondition(msg))
 	{
 		RCLCPP_INFO(this->get_logger(), "End of SetPos reached, holding...");
@@ -173,14 +149,14 @@ void CalibrateAxis::handleVescStatus(const rex_interfaces::msg::VescStatus::Cons
 		return;
 	}
 
-	// If motor is rotated more than allowed at once
+	// If motor is rotated outside the allowed calibration range
 	if (
 		mMode == Mode::SetVelocity &&
 		std::abs(msg->precise_pos) > mFloatParams[CALIBRATION_MAX_VELOCITY_SHIFT] &&
 		signum(mFrameToSend.set_value) == signum(msg->precise_pos) // Moving away from origin
 	)
 	{
-		RCLCPP_INFO(this->get_logger(), "Max velocity shift reached, snapping to %f", signum(msg->precise_pos) * (mFloatParams[CALIBRATION_MAX_VELOCITY_SHIFT] + 1));
+		RCLCPP_INFO(this->get_logger(), "Rotated more than is allowed in velocity mode, snapping to %f", signum(msg->precise_pos) * (mFloatParams[CALIBRATION_MAX_VELOCITY_SHIFT] + 1));
 		cancelTimeout();
 		// Snap to max shift
 		// +1 so that SetVelocity frames in the outer direction will still be rejected
@@ -206,6 +182,7 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 
 	// If motor is moving by SetVelocity, only STOP, CANCEL and SET_VELOCITY are fine
 	// If motor is moving by Offset, only STOP and CANCEL are fine
+	// If mMode is Hold or Nothing, all action types are allowed.
 	if (mMode == Mode::SetVelocity)
 	{
 		if (msg->action_type != CalibrateMsg::ACTION_TYPE_SET_VELOCITY &&
@@ -238,14 +215,14 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 	// --------------------
 
 	rex_interfaces::msg::VescMotorCommand fr;
-	float offsetShift;
+	// float offsetShift;
 	switch (msg->action_type)
 	{
 	case CalibrateMsg::ACTION_TYPE_STOP:
 		stopMotor(msg->vesc_id);
-		modeNothing(); // Clear the SetPos frame so that Hold doesn't use it
+		modeNothing(); // Clear the SetPos frame so that Hold doesn't use it (for safety reasons)
 		if (mIntParams[CALIBRATION_USE_SCHEDULE_HOLD])
-			mScheduleHold = true;
+			mHoldScheduled = true;
 		else
 			modeHold(msg->vesc_id);
 		break;
@@ -290,10 +267,12 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 		}
 
 		// Limit value
-		offsetShift = msg->value;
+		float offsetShift = msg->value;
 		if (std::abs(offsetShift) > mFloatParams[CALIBRATION_MAX_OFFSET_SHIFT])
 		{
-			RCLCPP_WARN(this->get_logger(), "Calibration: provided a relative offset that's too large (max %f)", mFloatParams[CALIBRATION_MAX_OFFSET_SHIFT]);
+			RCLCPP_WARN(this->get_logger(), "Calibration: can't move by offset that much at a time! (tried %f, max %f)",
+						offsetShift,
+						mFloatParams[CALIBRATION_MAX_OFFSET_SHIFT]);
 			offsetShift = std::clamp(offsetShift, -mFloatParams[CALIBRATION_MAX_OFFSET_SHIFT], mFloatParams[CALIBRATION_MAX_OFFSET_SHIFT]);
 		}
 
@@ -308,7 +287,8 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 		}
 
 		float precise_pos = mMotorStatuses[msg->vesc_id].position;
-		// Don't allow movement more than max shift
+		// Don't allow to rotate the motor more than CALIBRATION_MAX_VELOCITY_SHIFT
+		// away from origin.
 		// If you want to move further, you have to set origin and repeat
 		if (
 			std::abs(precise_pos) > mFloatParams[CALIBRATION_MAX_VELOCITY_SHIFT] &&
@@ -331,17 +311,17 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 			velocity = std::clamp(velocity, -mFloatParams[CALIBRATION_MAX_SPEED], mFloatParams[CALIBRATION_MAX_SPEED]);
 		}
 
-		// Handle the stop timers
+		// Velocity 0.0 is treated as a stop.
 		if (velocity == 0.0f)
 		{
 			// If not holding yet (and hold not scheduled)
-			if (mMode != Mode::Hold && !mScheduleHold)
+			if (mMode != Mode::Hold && !mHoldScheduled)
 			{
 				stopMotor(msg->vesc_id); // Also cancels timeout
 				if (mIntParams[CALIBRATION_USE_SCHEDULE_HOLD])
 				{
 					modeNothing();
-					mScheduleHold = true;
+					mHoldScheduled = true;
 				}
 				else
 					modeHold(msg->vesc_id);
@@ -371,10 +351,12 @@ void CalibrateAxis::handleRoverStatus(const rex_interfaces::msg::RoverStatus::Co
 	mLastRoverStatus = msg;
 }
 
+// ######################### MODES #########################
+
 void CalibrateAxis::modeNothing()
 {
 	RCLCPP_INFO(this->get_logger(), "MODE Nothing");
-	mScheduleHold = false;
+	mHoldScheduled = false;
 	mFrameToSend = rex_interfaces::msg::VescMotorCommand();
 	mMode = Mode::Nothing;
 	mCurrentMotorID = 0;
@@ -383,7 +365,7 @@ void CalibrateAxis::modeNothing()
 void CalibrateAxis::modeSetPos(VESC_Id_t vescID, float pos)
 {
 	RCLCPP_INFO(this->get_logger(), "MODE SetPos [%d]: %f", vescID, pos);
-	mScheduleHold = false;
+	mHoldScheduled = false;
 	mFrameToSend = frameSetPosition(vescID, pos);
 	mMode = Mode::SetPos;
 	mCurrentMotorID = vescID;
@@ -392,7 +374,7 @@ void CalibrateAxis::modeSetPos(VESC_Id_t vescID, float pos)
 void CalibrateAxis::modeSetVelocity(VESC_Id_t vescID, float velocity)
 {
 	RCLCPP_INFO(this->get_logger(), "MODE SetVelocity [%d]: %f", vescID, velocity);
-	mScheduleHold = false;
+	mHoldScheduled = false;
 	mFrameToSend = frameSetVelocity(vescID, velocity);
 	mMode = Mode::SetVelocity;
 	mCurrentMotorID = vescID;
@@ -400,7 +382,7 @@ void CalibrateAxis::modeSetVelocity(VESC_Id_t vescID, float velocity)
 
 void CalibrateAxis::modeHold(VESC_Id_t vescID)
 {
-	mScheduleHold = false;
+	mHoldScheduled = false;
 	if (mMode == Mode::SetPos)
 	{
 		// Keep sending the same frame
@@ -420,45 +402,7 @@ void CalibrateAxis::modeHold(VESC_Id_t vescID)
 	mCurrentMotorID = vescID;
 }
 
-bool CalibrateAxis::checkSetPosEndCondition(const rex_interfaces::msg::VescStatus::ConstSharedPtr &msg)
-{
-	// Checks if SetPos mode is ready to finished (wheel is at target position)
-	// Only run during Mode::SetPos!
-	if (mMode != Mode::SetPos)
-		return false;
-
-	// Scale related to https://github.com/AlvaroBajceps/libVescCan/issues/10
-	float targetValue = mFrameToSend.set_value * 100.0;
-
-	if (mIntParams[CALIBRATION_LOG_SETPOS_DIFF])
-		RCLCPP_INFO(
-			this->get_logger(), "Target is %f, current is %f, diff is %f, tolerance is %f",
-			targetValue, msg->precise_pos, std::abs(targetValue - msg->precise_pos), mFloatParams[CALIBRATION_STOP_TOLERANCE]);
-
-	return msg->erpm == 0 && std::abs(msg->precise_pos - targetValue) <= mFloatParams[CALIBRATION_STOP_TOLERANCE];
-}
-
-bool CalibrateAxis::isTimestampOutdated(rclcpp::Time stamp)
-{
-	rclcpp::Time now = this->get_clock()->now();
-	return (now - stamp).seconds() > mFloatParams[CALIBRATION_OUTDATED_DURATION_S];
-}
-
-bool CalibrateAxis::isRecordedStatusValid(VESC_Id_t vescID)
-{
-	// Checks if motor status is missing or outdated
-
-	if (!mMotorStatuses.count(vescID))
-	{
-		return false;
-	}
-
-	if (isTimestampOutdated(mMotorStatuses[vescID].receivedAt))
-	{
-		return false;
-	}
-	return true;
-}
+// ######################### TIMER-RELATED #########################
 
 void CalibrateAxis::startTimeout()
 {
@@ -470,6 +414,24 @@ void CalibrateAxis::cancelTimeout()
 	mVelocityTimeoutTimer->cancel();
 }
 
+void CalibrateAxis::timeoutTimerTick()
+{
+	if (mMode != Mode::SetVelocity)
+	{
+		RCLCPP_ERROR(this->get_logger(), "Error: timeout timer wasn't cancelled correctly!");
+	}
+	RCLCPP_INFO(this->get_logger(), "Motor [%d] stopped by timeout", mCurrentMotorID);
+	// stopMotor cancels the timer
+	stopMotor(mCurrentMotorID);
+	if (mIntParams[CALIBRATION_USE_SCHEDULE_HOLD])
+	{
+		modeNothing();
+		mHoldScheduled = true;
+	}
+	else
+		modeHold(mCurrentMotorID);
+}
+
 void CalibrateAxis::stopMotor(VESC_Id_t vescID)
 {
 	cancelTimeout();
@@ -477,6 +439,8 @@ void CalibrateAxis::stopMotor(VESC_Id_t vescID)
 	rex_interfaces::msg::VescMotorCommand fr = frameStop(vescID);
 	mCalibrationMotorCommandPub->publish(fr);
 }
+
+// ######################### CAN FRAMES #########################
 
 rex_interfaces::msg::VescMotorCommand CalibrateAxis::frameStop(VESC_Id_t vescID)
 {
@@ -530,4 +494,62 @@ rex_interfaces::msg::VescMotorCommand CalibrateAxis::frameSetVelocity(VESC_Id_t 
 	msg.header.stamp = this->get_clock()->now();
 
 	return msg;
+}
+
+void CalibrateAxis::sendFrame()
+{
+	if (!mLastRoverStatus || mLastRoverStatus->control_mode != rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP)
+		return;
+	if (mMode != Mode::Nothing)
+	{
+		mFrameToSend.header.stamp = this->get_clock()->now();
+		mCalibrationMotorCommandPub->publish(mFrameToSend);
+	}
+}
+
+// ######################### UTILITY #########################
+bool CalibrateAxis::calibrationMotorsContains(VESC_Id_t vescID)
+{
+	// Check if the supplied ID is in the list of motors allowed for calibration.
+	return std::find(mCalibrationMotors.begin(), mCalibrationMotors.end(), vescID) != mCalibrationMotors.end();
+}
+
+bool CalibrateAxis::checkSetPosEndCondition(const rex_interfaces::msg::VescStatus::ConstSharedPtr &msg)
+{
+	// Checks if SetPos mode is ready to finished (wheel is at target position)
+	// Only run during Mode::SetPos!
+	if (mMode != Mode::SetPos)
+		return false;
+
+	// Scale related to https://github.com/AlvaroBajceps/libVescCan/issues/10
+	float targetValue = mFrameToSend.set_value * 100.0;
+
+	if (mIntParams[CALIBRATION_LOG_SETPOS_DIFF])
+		RCLCPP_INFO(
+			this->get_logger(), "Target is %f, current is %f, diff is %f, tolerance is %f",
+			targetValue, msg->precise_pos, std::abs(targetValue - msg->precise_pos), mFloatParams[CALIBRATION_STOP_TOLERANCE]);
+
+	return msg->erpm == 0 && std::abs(msg->precise_pos - targetValue) <= mFloatParams[CALIBRATION_STOP_TOLERANCE];
+}
+
+bool CalibrateAxis::isTimestampOutdated(rclcpp::Time stamp)
+{
+	rclcpp::Time now = this->get_clock()->now();
+	return (now - stamp).seconds() > mFloatParams[CALIBRATION_OUTDATED_DURATION_S];
+}
+
+bool CalibrateAxis::isRecordedStatusValid(VESC_Id_t vescID)
+{
+	// Checks if motor status is missing or outdated
+
+	if (!mMotorStatuses.count(vescID))
+	{
+		return false;
+	}
+
+	if (isTimestampOutdated(mMotorStatuses[vescID].receivedAt))
+	{
+		return false;
+	}
+	return true;
 }

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -1,17 +1,17 @@
 #include "calibration_manager/CalibrateAxis.hpp"
 
-const std::string CALIBRATION_MAX_SPEED = "calibration.max_speed";
-const std::string CALIBRATION_MAX_OFFSET_SHIFT = "calibration.max_offset_shift";
-const std::string CALIBRATION_MAX_VELOCITY_SHIFT = "calibration.max_velocity_shift";
+const std::string CALIBRATION_MAX_SPEED = "max_speed";
+const std::string CALIBRATION_MAX_OFFSET_SHIFT = "max_offset_shift";
+const std::string CALIBRATION_MAX_VELOCITY_SHIFT = "max_velocity_shift";
 
-const std::string CALIBRATION_OUTDATED_DURATION_S = "calibration.outdated_duration_s";
-const std::string CALIBRATION_SPEED_TIMEOUT_MS = "calibration.speed_timeout_ms";
-const std::string CALIBRATION_MESSAGE_SEND_PERIOD_MS = "calibration.message_send_period_ms";
+const std::string CALIBRATION_OUTDATED_DURATION_S = "outdated_duration_s";
+const std::string CALIBRATION_SPEED_TIMEOUT_MS = "speed_timeout_ms";
+const std::string CALIBRATION_MESSAGE_SEND_PERIOD_MS = "message_send_period_ms";
 
-const std::string CALIBRATION_STOP_TOLERANCE = "calibration.stop_tolerance";
+const std::string CALIBRATION_STOP_TOLERANCE = "stop_tolerance";
 
-const std::string CALIBRATION_LOG_SETPOS_DIFF = "calibration.log_setpos_diff";
-const std::string CALIBRATION_USE_SCHEDULE_HOLD = "calibration.use_schedule_hold";
+const std::string CALIBRATION_LOG_SETPOS_DIFF = "log_setpos_diff";
+const std::string CALIBRATION_USE_SCHEDULE_HOLD = "use_schedule_hold";
 
 template <typename T>
 int signum(T val)

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -184,9 +184,19 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 {
 	using CalibrateMsg = rex_interfaces::msg::CalibrateAxis;
 
-	if (!mLastRoverStatus || mLastRoverStatus->control_mode != rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP)
+	if (!mLastRoverStatus)
+	{
+		RCLCPP_ERROR(this->get_logger(), "Rover status unknown, calibration not permitted.");
+		return;
+	}
+	if (mLastRoverStatus->control_mode != rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP)
 	{
 		RCLCPP_ERROR(this->get_logger(), "Rover not in ESTOP, calibration not permitted.");
+		return;
+	}
+	if (mLastRoverStatus->communication_state != rex_interfaces::msg::RoverStatus::COMMUNICATION_STATE_OPENED)
+	{
+		RCLCPP_ERROR(this->get_logger(), "Rover communication not opened, calibration not permitted.");
 		return;
 	}
 	if (!mLastBatteryInfo || mLastBatteryInfo->hotswap_status & rex_interfaces::msg::BatteryInfo::DRIVE_STOP)
@@ -358,9 +368,10 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 
 void CalibrateAxis::handleRoverStatus(const rex_interfaces::msg::RoverStatus::ConstSharedPtr &msg)
 {
-	if (mLastRoverStatus &&
-		mLastRoverStatus->control_mode == rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP &&
-		msg->control_mode != rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP)
+	const bool wasCalibrationAllowed = mLastRoverStatus && isCalibrationAllowedByRoverStatus(mLastRoverStatus);
+	const bool isCalibrationAllowed = isCalibrationAllowedByRoverStatus(msg);
+
+	if (wasCalibrationAllowed && !isCalibrationAllowed)
 	{
 		if (mMode == Mode::SetPos || mMode == Mode::SetVelocity)
 			stopMotor(mCurrentMotorID);
@@ -371,13 +382,12 @@ void CalibrateAxis::handleRoverStatus(const rex_interfaces::msg::RoverStatus::Co
 
 void CalibrateAxis::handleBatteryInfo(const rex_interfaces::msg::BatteryInfo::ConstSharedPtr &msg)
 {
+	const bool wasBlackMushroomPressed = mLastBatteryInfo && isBlackMushroomPressed(mLastBatteryInfo);
+	const bool isBlackMushroomPressedNow = isBlackMushroomPressed(msg);
 	// Black mushroom pressed
-	if (isBlackMushroomPressed(msg))
+	if (!wasBlackMushroomPressed && isBlackMushroomPressedNow)
 	{
-		if (!mLastBatteryInfo || !isBlackMushroomPressed(mLastBatteryInfo))
-		{
-			modeNothing();
-		}
+		modeNothing();
 	}
 	mLastBatteryInfo = msg;
 }
@@ -538,8 +548,7 @@ rex_interfaces::msg::VescMotorCommand CalibrateAxis::frameSetVelocity(VESC_Id_t 
 
 void CalibrateAxis::sendFrame()
 {
-	if (
-		!mLastRoverStatus || mLastRoverStatus->control_mode != rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP ||
+	if (!isCalibrationAllowedByRoverStatus(mLastRoverStatus) ||
 		!mLastBatteryInfo || isBlackMushroomPressed(mLastBatteryInfo))
 		return;
 	if (mMode != Mode::Nothing)
@@ -632,4 +641,10 @@ float CalibrateAxis::getTargetPosFromSetPosFrame(rex_interfaces::msg::VescMotorC
 bool CalibrateAxis::isBlackMushroomPressed(const rex_interfaces::msg::BatteryInfo::ConstSharedPtr &msg)
 {
 	return msg->hotswap_status & rex_interfaces::msg::BatteryInfo::DRIVE_STOP;
+}
+
+bool CalibrateAxis::isCalibrationAllowedByRoverStatus(const rex_interfaces::msg::RoverStatus::ConstSharedPtr &msg) const
+{
+	return msg->control_mode == rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP &&
+		   msg->communication_state == rex_interfaces::msg::RoverStatus::COMMUNICATION_STATE_OPENED;
 }

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -11,7 +11,6 @@ const std::string CALIBRATION_MESSAGE_SEND_PERIOD_MS = "message_send_period_ms";
 const std::string CALIBRATION_STOP_TOLERANCE = "stop_tolerance";
 
 const std::string CALIBRATION_LOG_SETPOS_DIFF = "log_setpos_diff";
-const std::string CALIBRATION_USE_SCHEDULE_HOLD = "use_schedule_hold";
 
 CalibrateAxis::CalibrateAxis(const rclcpp::NodeOptions &options) : Node("calibrate_axis", options)
 {
@@ -51,7 +50,6 @@ CalibrateAxis::CalibrateAxis(const rclcpp::NodeOptions &options) : Node("calibra
 	mVelocityTimeoutTimer->cancel();
 
 	modeNothing();
-	mHoldScheduled = false;
 
 	RCLCPP_INFO(this->get_logger(), "Calibration module started.");
 };
@@ -76,8 +74,7 @@ void CalibrateAxis::initParams()
 	mIntParams = {
 		{CALIBRATION_SPEED_TIMEOUT_MS, 500},
 		{CALIBRATION_MESSAGE_SEND_PERIOD_MS, 1000 / 50},
-		{CALIBRATION_LOG_SETPOS_DIFF, 0},
-		{CALIBRATION_USE_SCHEDULE_HOLD, 1}};
+		{CALIBRATION_LOG_SETPOS_DIFF, 0}};
 	for (auto &[name, value] : mIntParams)
 	{
 		this->declare_parameter(name, value);
@@ -119,20 +116,6 @@ void CalibrateAxis::handleVescStatus(const rex_interfaces::msg::VescStatus::Cons
 
 	if (msg->vesc_id != mCurrentMotorID)
 		return;
-
-	if (mHoldScheduled)
-	{
-		if (mMode != Mode::Nothing)
-		{
-			RCLCPP_ERROR(this->get_logger(), "Hold schedule wasn't cancelled correctly! Any mode changes should cancel it.");
-		}
-		else
-		{
-			// Now that new status has been received, motor can Hold (prevents jerk when stopping during SetVelocity)
-			modeHold(mCurrentMotorID);
-			return;
-		}
-	}
 
 	// --- Mode end-conditions below
 
@@ -179,6 +162,16 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 		return;
 	}
 
+	// If a different motor is currently being calibrated,
+	// stop it and forget it.
+	if (mCurrentMotorID && mCurrentMotorID != msg->vesc_id)
+	{
+		stopMotor(mCurrentMotorID);
+		modeNothing();
+	}
+
+	// --------------------
+
 	// If motor is moving by SetVelocity, only STOP, CANCEL and SET_VELOCITY are fine
 	// If motor is moving by Offset, only STOP and CANCEL are fine
 	// If mMode is Hold or Nothing, all action types are allowed.
@@ -203,16 +196,6 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 
 	// --------------------
 
-	// If a different motor is currently being calibrated,
-	// stop it and forget it.
-	if (mCurrentMotorID && mCurrentMotorID != msg->vesc_id)
-	{
-		stopMotor(mCurrentMotorID);
-		modeNothing();
-	}
-
-	// --------------------
-
 	rex_interfaces::msg::VescMotorCommand fr;
 	float offsetShift;
 	switch (msg->action_type)
@@ -220,10 +203,7 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 	case CalibrateMsg::ACTION_TYPE_STOP:
 		stopMotor(msg->vesc_id);
 		modeNothing(); // Clear the SetPos frame so that Hold doesn't use it (for safety reasons)
-		if (mIntParams[CALIBRATION_USE_SCHEDULE_HOLD])
-			scheduleHold(msg->vesc_id);
-		else
-			modeHold(msg->vesc_id);
+		modeHold(msg->vesc_id);
 		break;
 
 	case CalibrateMsg::ACTION_TYPE_RETURN_TO_ORIGIN:
@@ -282,6 +262,11 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 		if (!isRecordedStatusValid(msg->vesc_id))
 		{
 			RCLCPP_ERROR(this->get_logger(), "No recent motor status recorded - cannot verify starting position, won't rotate.");
+			if (mMode == Mode::SetVelocity)
+			{
+				stopMotor(msg->vesc_id);
+				modeNothing();
+			}
 			return;
 		}
 
@@ -298,7 +283,10 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 				this->get_logger(), *this->get_clock(), 5 * 1000,
 				"Trying to move too far at once. To rotate more, set origin and try again.");
 			if (mMode == Mode::SetVelocity)
+			{
+				stopMotor(msg->vesc_id);
 				modeNothing();
+			}
 			return;
 		}
 
@@ -313,19 +301,12 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 		// Velocity 0.0 is treated as a stop.
 		if (velocity == 0.0f)
 		{
-			// If not holding yet (and hold not scheduled)
-			if (mMode != Mode::Hold && !mHoldScheduled)
+			// If not holding yet
+			if (mMode != Mode::Hold)
 			{
 				stopMotor(msg->vesc_id); // Also cancels timeout
-				if (mIntParams[CALIBRATION_USE_SCHEDULE_HOLD])
-				{
-					modeNothing();
-					scheduleHold(msg->vesc_id);
-				}
-				else
-					modeHold(msg->vesc_id);
+				modeHold(msg->vesc_id);
 			}
-			// Already holding, do nothing
 		}
 		else
 		{
@@ -352,6 +333,7 @@ void CalibrateAxis::handleRoverStatus(const rex_interfaces::msg::RoverStatus::Co
 
 void CalibrateAxis::handleBatteryInfo(const rex_interfaces::msg::BatteryInfo::ConstSharedPtr &msg)
 {
+	// Black mushroom pressed
 	if (msg->hotswap_status & rex_interfaces::msg::BatteryInfo::DRIVE_STOP)
 	{
 		if (!mLastBatteryInfo ||
@@ -368,7 +350,6 @@ void CalibrateAxis::handleBatteryInfo(const rex_interfaces::msg::BatteryInfo::Co
 void CalibrateAxis::modeNothing()
 {
 	RCLCPP_INFO(this->get_logger(), "MODE Nothing");
-	mHoldScheduled = false;
 	mFrameToSend = rex_interfaces::msg::VescMotorCommand();
 	mMode = Mode::Nothing;
 	mCurrentMotorID = 0;
@@ -378,7 +359,6 @@ void CalibrateAxis::modeNothing()
 void CalibrateAxis::modeSetPos(VESC_Id_t vescID, float pos)
 {
 	RCLCPP_INFO(this->get_logger(), "MODE SetPos [%d]: %f", vescID, pos);
-	mHoldScheduled = false;
 	mFrameToSend = frameSetPosition(vescID, pos);
 	mMode = Mode::SetPos;
 	mCurrentMotorID = vescID;
@@ -387,7 +367,6 @@ void CalibrateAxis::modeSetPos(VESC_Id_t vescID, float pos)
 void CalibrateAxis::modeSetVelocity(VESC_Id_t vescID, float velocity)
 {
 	RCLCPP_INFO(this->get_logger(), "MODE SetVelocity [%d]: %f", vescID, velocity);
-	mHoldScheduled = false;
 	mFrameToSend = frameSetVelocity(vescID, velocity);
 	mMode = Mode::SetVelocity;
 	mCurrentMotorID = vescID;
@@ -395,22 +374,21 @@ void CalibrateAxis::modeSetVelocity(VESC_Id_t vescID, float velocity)
 
 void CalibrateAxis::modeHold(VESC_Id_t vescID)
 {
-	mHoldScheduled = false;
 	if (mMode == Mode::SetPos)
 	{
 		// Keep sending the same frame
 		mMode = Mode::Hold;
 	}
-	else if (!isRecordedStatusValid(vescID))
+	else if (isRecordedStatusValid(vescID))
+	{
+		mFrameToSend = frameSetPosition(vescID, mMotorStatuses[vescID].position);
+		mMode = Mode::Hold;
+	}
+	else
 	{
 		RCLCPP_ERROR(this->get_logger(), "Tried to hold, but position is outdated");
 		modeNothing();
 		return;
-	}
-	else
-	{
-		mFrameToSend = frameSetPosition(vescID, mMotorStatuses[vescID].position);
-		mMode = Mode::Hold;
 	}
 	RCLCPP_INFO(this->get_logger(), "MODE Hold [%d]: %f", vescID, mFrameToSend.set_value * 100.0);
 	mCurrentMotorID = vescID;
@@ -445,13 +423,7 @@ void CalibrateAxis::timeoutTimerTick()
 	}
 	RCLCPP_INFO(this->get_logger(), "Motor [%d] stopped by timeout", vescID);
 	stopMotor(vescID);
-	if (mIntParams[CALIBRATION_USE_SCHEDULE_HOLD])
-	{
-		modeNothing();
-		scheduleHold(vescID);
-	}
-	else
-		modeHold(vescID);
+	modeHold(vescID);
 	cancelTimeout();
 }
 
@@ -576,12 +548,6 @@ bool CalibrateAxis::isRecordedStatusValid(VESC_Id_t vescID)
 		return false;
 	}
 	return true;
-}
-
-void CalibrateAxis::scheduleHold(VESC_Id_t vescID)
-{
-	mHoldScheduled = true;
-	mCurrentMotorID = vescID;
 }
 
 template <typename T>

--- a/src/calibration_manager/src/CalibrateAxis.cpp
+++ b/src/calibration_manager/src/CalibrateAxis.cpp
@@ -13,16 +13,6 @@ const std::string CALIBRATION_STOP_TOLERANCE = "stop_tolerance";
 const std::string CALIBRATION_LOG_SETPOS_DIFF = "log_setpos_diff";
 const std::string CALIBRATION_USE_SCHEDULE_HOLD = "use_schedule_hold";
 
-template <typename T>
-int signum(T val)
-{
-	if (val > 0)
-		return 1;
-	if (val < 0)
-		return -1;
-	return 0;
-}
-
 CalibrateAxis::CalibrateAxis(const rclcpp::NodeOptions &options) : Node("calibrate_axis", options)
 {
 	const rclcpp::QoS qos = rclcpp::QoS(rclcpp::KeepLast(256));
@@ -50,6 +40,9 @@ CalibrateAxis::CalibrateAxis(const rclcpp::NodeOptions &options) : Node("calibra
 	mRoverStatusSub = this->create_subscription<rex_interfaces::msg::RoverStatus>(
 		RosCanConstants::RosTopics::mqtt_rover_status,
 		qos, std::bind(&CalibrateAxis::handleRoverStatus, this, std::placeholders::_1));
+	mBatteryInfoSub = this->create_subscription<rex_interfaces::msg::BatteryInfo>(
+		RosCanConstants::RosTopics::can_battery_info,
+		qos, std::bind(&CalibrateAxis::handleBatteryInfo, this, std::placeholders::_1));
 
 	mFrameSender = this->create_timer(
 		std::chrono::milliseconds(mIntParams[CALIBRATION_MESSAGE_SEND_PERIOD_MS]),
@@ -110,6 +103,7 @@ void CalibrateAxis::initParams()
 }
 
 // ######################### MSG HANDLERS #########################
+
 void CalibrateAxis::handleVescStatus(const rex_interfaces::msg::VescStatus::ConstSharedPtr &msg)
 {
 	// RCLCPP_INFO(this->get_logger(), "%d precise %lf pid %f", msg->vesc_id, msg->precise_pos, msg->pid_pos);
@@ -128,7 +122,7 @@ void CalibrateAxis::handleVescStatus(const rex_interfaces::msg::VescStatus::Cons
 
 	if (mHoldScheduled)
 	{
-		if (mMode == Mode::Nothing)
+		if (mMode != Mode::Nothing)
 		{
 			RCLCPP_ERROR(this->get_logger(), "Hold schedule wasn't cancelled correctly! Any mode changes should cancel it.");
 		}
@@ -171,6 +165,11 @@ void CalibrateAxis::handleCalibrateAxis(const rex_interfaces::msg::CalibrateAxis
 	if (!mLastRoverStatus || mLastRoverStatus->control_mode != rex_interfaces::msg::RoverStatus::CONTROL_MODE_ESTOP)
 	{
 		RCLCPP_ERROR(this->get_logger(), "Rover not in ESTOP, calibration not permitted.");
+		return;
+	}
+	if (!mLastBatteryInfo || mLastBatteryInfo->hotswap_status & rex_interfaces::msg::BatteryInfo::DRIVE_STOP)
+	{
+		RCLCPP_ERROR(this->get_logger(), "Black mushroom enganed (or status unknown), calibration not permitted.");
 		return;
 	}
 
@@ -351,6 +350,19 @@ void CalibrateAxis::handleRoverStatus(const rex_interfaces::msg::RoverStatus::Co
 	mLastRoverStatus = msg;
 }
 
+void CalibrateAxis::handleBatteryInfo(const rex_interfaces::msg::BatteryInfo::ConstSharedPtr &msg)
+{
+	if (msg->hotswap_status & rex_interfaces::msg::BatteryInfo::DRIVE_STOP)
+	{
+		if (!mLastBatteryInfo ||
+			!(mLastBatteryInfo->hotswap_status & rex_interfaces::msg::BatteryInfo::DRIVE_STOP))
+		{
+			modeNothing();
+		}
+	}
+	mLastBatteryInfo = msg;
+}
+
 // ######################### MODES #########################
 
 void CalibrateAxis::modeNothing()
@@ -508,6 +520,7 @@ void CalibrateAxis::sendFrame()
 }
 
 // ######################### UTILITY #########################
+
 bool CalibrateAxis::calibrationMotorsContains(VESC_Id_t vescID)
 {
 	// Check if the supplied ID is in the list of motors allowed for calibration.
@@ -552,4 +565,14 @@ bool CalibrateAxis::isRecordedStatusValid(VESC_Id_t vescID)
 		return false;
 	}
 	return true;
+}
+
+template <typename T>
+int signum(T val)
+{
+	if (val > 0)
+		return 1;
+	if (val < 0)
+		return -1;
+	return 0;
 }

--- a/src/calibration_manager/src/calibration_manager.cpp
+++ b/src/calibration_manager/src/calibration_manager.cpp
@@ -1,0 +1,16 @@
+#include "rclcpp/rclcpp.hpp"
+#include "calibration_manager/CalibrateAxis.hpp"
+
+int main(int argc, char **argv)
+{
+  rclcpp::init(argc, argv);
+  auto n = rclcpp::Node::make_shared("calibration_manager");
+
+  CalibrateAxis mCalibrateAxis(n);
+
+  RCLCPP_INFO(n->get_logger(), "Calibration Manager node started.");
+
+  rclcpp::spin(n);
+  rclcpp::shutdown();
+  return 0;
+}

--- a/src/calibration_manager/src/calibration_manager.cpp
+++ b/src/calibration_manager/src/calibration_manager.cpp
@@ -1,16 +1,4 @@
-#include "rclcpp/rclcpp.hpp"
+#include <rclcpp_components/register_node_macro.hpp>
 #include "calibration_manager/CalibrateAxis.hpp"
 
-int main(int argc, char **argv)
-{
-  rclcpp::init(argc, argv);
-  auto n = rclcpp::Node::make_shared("calibration_manager");
-
-  CalibrateAxis mCalibrateAxis(n);
-
-  RCLCPP_INFO(n->get_logger(), "Calibration Manager node started.");
-
-  rclcpp::spin(n);
-  rclcpp::shutdown();
-  return 0;
-}
+RCLCPP_COMPONENTS_REGISTER_NODE(CalibrateAxis)

--- a/src/can_bridge/include/can_bridge/MotorControl.hpp
+++ b/src/can_bridge/include/can_bridge/MotorControl.hpp
@@ -42,6 +42,7 @@ private:
 	void handleSetMotorVel(const rex_interfaces::msg::Wheels::ConstSharedPtr &msg);
 	void handleBatteryInfo(const rex_interfaces::msg::BatteryInfo::ConstSharedPtr &msg);
 	void handleRoverStatus(const rex_interfaces::msg::RoverStatus::ConstSharedPtr &msg);
+	void handleCalibrationMotorCommand(const rex_interfaces::msg::VescMotorCommand::ConstSharedPtr &msg);
 	void stopMotors();
 	void setWheelsOrigin();
 	void setCorrectState();
@@ -53,6 +54,7 @@ private:
 	rclcpp::Subscription<rex_interfaces::msg::Wheels>::SharedPtr mSetMotorVelSub; /**< ROS2 subscriber for motor velocity messages. */
 	rclcpp::Subscription<rex_interfaces::msg::BatteryInfo>::SharedPtr mBatteryInfoSub;
 	rclcpp::Subscription<rex_interfaces::msg::RoverStatus>::SharedPtr mRoverStatusSub;
+	rclcpp::Subscription<rex_interfaces::msg::VescMotorCommand>::SharedPtr mCalibrationMotorCommandSub;
 
 	rex_interfaces::msg::Wheels::ConstSharedPtr mLastSentFrame;
 	rex_interfaces::msg::BatteryInfo::ConstSharedPtr mLastBatteryInfo;

--- a/src/can_bridge/include/can_bridge/RosCanConstants.hpp
+++ b/src/can_bridge/include/can_bridge/RosCanConstants.hpp
@@ -11,19 +11,21 @@ struct RosCanConstants
 {
 	struct RosTopics
 	{
-		static const std::string can_raw_RX;			/**< Topic for all received CAN messages. */
-		static const std::string can_raw_TX;			/**< Topic for all sent CAN messages. */
-		static const std::string can_set_motor_vel;		/**< Topic used for setting the motor velocity. */
-		static const std::string can_get_motor_vel;		/**< Topic used for getting the real motor velocity. */
-		static const std::string can_get_motor_current; /**< Topic used for getting the real motor velocity. */
-		static const std::string can_stm_errors;		/**< Topic used for reporting STM32 errors. */
-		static const std::string can_stm_init;			/**< Topic used for initializing the STM32. */
-		static const std::string can_vesc_status;		/**< Topic with vesc motor status */
-		static const std::string can_manipulator_ctl;	/**< Topic used for manipulator 'manipulation' */
-		static const std::string can_sampler_status;	/**< Topic with sampler status */
-		static const std::string can_battery_info;		/**< Topic with battery (BMS & HOTSWAP) status */
-		static const std::string mqtt_rover_status;		/**< Topic for rover status from MQTT. */
-		static const std::string mqtt_sampler_control;	/**< Topic for sampler control from MQTT. */
+		static const std::string can_raw_RX;					/**< Topic for all received CAN messages. */
+		static const std::string can_raw_TX;					/**< Topic for all sent CAN messages. */
+		static const std::string can_set_motor_vel;				/**< Topic used for setting the motor velocity. */
+		static const std::string can_get_motor_vel;				/**< Topic used for getting the real motor velocity. */
+		static const std::string can_get_motor_current;			/**< Topic used for getting the real motor velocity. */
+		static const std::string can_stm_errors;				/**< Topic used for reporting STM32 errors. */
+		static const std::string can_stm_init;					/**< Topic used for initializing the STM32. */
+		static const std::string can_vesc_status;				/**< Topic with vesc motor status */
+		static const std::string can_manipulator_ctl;			/**< Topic used for manipulator 'manipulation' */
+		static const std::string can_sampler_status;			/**< Topic with sampler status */
+		static const std::string can_battery_info;				/**< Topic with battery (BMS & HOTSWAP) status */
+		static const std::string can_calibration_motor_command; /**< Topic used for VESC commands during calibration */
+		static const std::string mqtt_rover_status;				/**< Topic for rover status from MQTT. */
+		static const std::string mqtt_sampler_control;			/**< Topic for sampler control from MQTT. */
+		static const std::string mqtt_calibrate_axis;			/**< Topic used to calibrate motors (wheels, manipulator) */
 	};
 
 	struct VescIds

--- a/src/can_bridge/src/MotorControl.cpp
+++ b/src/can_bridge/src/MotorControl.cpp
@@ -20,7 +20,7 @@ MotorControl::MotorControl(rclcpp::Node::SharedPtr &nh) : mNh(nh)
 		RosCanConstants::RosTopics::mqtt_rover_status,
 		qos, std::bind(&MotorControl::handleRoverStatus, this, std::placeholders::_1));
 	mCalibrationMotorCommandSub = mNh->create_subscription<rex_interfaces::msg::VescMotorCommand>(
-		RosCanConstants::RosTopics::mqtt_calibrate_axis,
+		RosCanConstants::RosTopics::can_calibration_motor_command,
 		qos, std::bind(&MotorControl::handleCalibrationMotorCommand, this, std::placeholders::_1));
 
 	mTimer = mNh->create_timer(std::chrono::milliseconds(500), std::bind(&MotorControl::handleTimerClb, this));

--- a/src/can_bridge/src/RosCanConstants.cpp
+++ b/src/can_bridge/src/RosCanConstants.cpp
@@ -11,9 +11,11 @@ const std::string RosCanConstants::RosTopics::can_vesc_status = "/CAN/RX/vesc_st
 const std::string RosCanConstants::RosTopics::can_manipulator_ctl = "/CAN/TX/manipulator_ctl";
 const std::string RosCanConstants::RosTopics::can_sampler_status = "/CAN/RX/sampler_status";
 const std::string RosCanConstants::RosTopics::can_battery_info = "/CAN/RX/battery_info";
+const std::string RosCanConstants::RosTopics::can_calibration_motor_command = "/CAN/TX/calibration_motor_command";
 
 const std::string RosCanConstants::RosTopics::mqtt_rover_status = "/MQTT/RoverStatus";
 const std::string RosCanConstants::RosTopics::mqtt_sampler_control = "/MQTT/SamplerControl";
+const std::string RosCanConstants::RosTopics::mqtt_calibrate_axis = "/MQTT/CalibrateAxis";
 
 const uint8_t RosCanConstants::VescIds::ros_can_host = 0x20; /**< ID for the computer that interconnects ROS and CAN BUS. */
 

--- a/src/mqtt_bridge/include/mqtt_bridge/ROSTopicHandler.hpp
+++ b/src/mqtt_bridge/include/mqtt_bridge/ROSTopicHandler.hpp
@@ -11,6 +11,7 @@
 #include "rex_interfaces/msg/manipulator_mqtt_message.hpp"
 #include "rex_interfaces/msg/battery_info.hpp"
 #include "rex_interfaces/msg/sampler_feedback.hpp"
+#include "rex_interfaces/msg/calibrate_axis.hpp"
 #define RAPIDJSON_HAS_STDSTRING 1
 #include "rapidjson/document.h"
 
@@ -30,6 +31,7 @@ public:
   void publishMessage_ManipulatorControl(rex_interfaces::msg::ManipulatorMqttMessage message);
   void publishMessage_SamplerControl(rex_interfaces::msg::SamplerControl message);
   void publishMessage_RoverStatus(rex_interfaces::msg::RoverStatus message);
+  void publishMessage_CalibrateAxis(rex_interfaces::msg::CalibrateAxis message);
 
 private:
   void publishMqttMessage(const std::string topicName, const char *message);
@@ -72,6 +74,7 @@ private:
   rclcpp::Publisher<rex_interfaces::msg::ManipulatorMqttMessage>::SharedPtr mPub_ManipulatorControl;
   rclcpp::Publisher<rex_interfaces::msg::SamplerControl>::SharedPtr mPub_SamplerControl;
   rclcpp::Publisher<rex_interfaces::msg::RoverStatus>::SharedPtr mPub_RoverStatus;
+  rclcpp::Publisher<rex_interfaces::msg::CalibrateAxis>::SharedPtr mPub_CalibrateAxis;
 
   rclcpp::CallbackGroup::SharedPtr timer_cb_group;
 

--- a/src/mqtt_bridge/src/ROSTopicHandler.cpp
+++ b/src/mqtt_bridge/src/ROSTopicHandler.cpp
@@ -27,6 +27,7 @@ ROSTopicHandler::ROSTopicHandler(std::shared_ptr<mqtt::async_client> mqttClient,
 	mPub_ManipulatorControl = n->create_publisher<rex_interfaces::msg::ManipulatorMqttMessage>("/MQTT/ManipulatorControl", 1000);
 	mPub_SamplerControl = n->create_publisher<rex_interfaces::msg::SamplerControl>("/MQTT/SamplerControl", 1000);
 	mPub_RoverStatus = n->create_publisher<rex_interfaces::msg::RoverStatus>("/MQTT/RoverStatus", 1000);
+	mPub_CalibrateAxis = n->create_publisher<rex_interfaces::msg::CalibrateAxis>("/MQTT/CalibrateAxis", 1000);
 }
 
 void ROSTopicHandler::publishMqttMessage(const std::string topicName, const char *message)
@@ -381,4 +382,11 @@ void ROSTopicHandler::publishMessage_SamplerControl(rex_interfaces::msg::Sampler
 void ROSTopicHandler::publishMessage_RoverStatus(rex_interfaces::msg::RoverStatus message)
 {
 	mPub_RoverStatus->publish(message);
+}
+
+// ##### CalibrateAxis ######
+
+void ROSTopicHandler::publishMessage_CalibrateAxis(rex_interfaces::msg::CalibrateAxis message)
+{
+	mPub_CalibrateAxis->publish(message);
 }

--- a/src/mqtt_bridge/src/mqtt_bridge_node.cpp
+++ b/src/mqtt_bridge/src/mqtt_bridge_node.cpp
@@ -198,6 +198,36 @@ void processMqttRoverStatusMessage(const char *payloadMsg, std::shared_ptr<ROSTo
 	}
 }
 
+void processMqttCalibrateAxisMessage(const char *payloadMsg, std::shared_ptr<ROSTopicHandler> rth, std::shared_ptr<rclcpp::Node> node)
+{
+	rapidjson::Document d;
+	rapidjson::ParseResult ok = d.Parse(payloadMsg);
+
+	if (!ok)
+	{
+		RCLCPP_WARN_STREAM(node->get_logger(), "JSON parse error: " << rapidjson::GetParseError_En(ok.Code()) << " (" << ok.Offset() << "), discarding MQTT message.");
+	}
+	else
+	{
+		try
+		{
+			rex_interfaces::msg::CalibrateAxis msg;
+
+			msg.vesc_id = d["VescID"].GetUint();
+			msg.value = d["Value"].GetDouble();
+			msg.action_type = d["ActionType"].GetUint();
+
+			msg.header.stamp = unixMillisecondsToROSTimestamp(d["Timestamp"].GetUint64());
+
+			rth->publishMessage_CalibrateAxis(msg);
+		}
+		catch (JsonAssertException e)
+		{
+			RCLCPP_WARN(node->get_logger(), "JSON assert exception, discarding MQTT message.");
+		}
+	}
+}
+
 int main(int argc, char *argv[])
 {
 	rclcpp::init(argc, argv);
@@ -220,8 +250,8 @@ int main(int argc, char *argv[])
 	const bool CLEAN_START = false;
 
 
-	auto SUBSCRIBED_TOPICS_NAMES = mqtt::string_collection::create({"RappTORS/Wheels", "RappTORS/RoverControl", "RappTORS/ManipulatorControl", "RappTORS/SamplerControl", "RappTORS/RoverStatus"});
-	const std::vector<int> SUBSCRIBED_TOPICS_QOS{0, 0, 0, 0, 0};
+	auto SUBSCRIBED_TOPICS_NAMES = mqtt::string_collection::create({"RappTORS/Wheels", "RappTORS/RoverControl", "RappTORS/ManipulatorControl", "RappTORS/SamplerControl", "RappTORS/RoverStatus", "RappTORS/CalibrateAxis"});
+	const std::vector<int> SUBSCRIBED_TOPICS_QOS{0, 0, 0, 0, 0, 0};
 
 	auto param_desc = rcl_interfaces::msg::ParameterDescriptor{};
     param_desc.read_only = true;
@@ -290,6 +320,8 @@ int main(int argc, char *argv[])
 			processMqttSamplerControlMessage(mqtt_msg->get_payload_str().c_str(), rth, node);
 		} else if (messageTopic == "RappTORS/RoverStatus") {
 			processMqttRoverStatusMessage(mqtt_msg->get_payload_str().c_str(), rth, node);
+		} else if (messageTopic == "RappTORS/CalibrateAxis") {
+			processMqttCalibrateAxisMessage(mqtt_msg->get_payload_str().c_str(), rth, node);
 		} else {
 			RCLCPP_WARN_STREAM(node->get_logger(), "Unknown MQTT topic: " << messageTopic << ", discarding MQTT message.");
 		} });

--- a/src/ros_constants/CMakeLists.txt
+++ b/src/ros_constants/CMakeLists.txt
@@ -1,0 +1,55 @@
+cmake_minimum_required(VERSION 3.8)
+project(ros_constants)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+# find dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+
+add_library(${PROJECT_NAME}
+  src/RosCanConstants.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+	$<INSTALL_INTERFACE:include>
+)
+
+target_link_libraries(${PROJECT_NAME} PUBLIC
+  rclcpp::rclcpp
+)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT export_${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+)
+
+install(
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+  DESTINATION include
+)
+
+install(EXPORT export_${PROJECT_NAME}
+    FILE ${PROJECT_NAME}Config.cmake
+    NAMESPACE ${PROJECT_NAME}::
+    DESTINATION lib/cmake/${PROJECT_NAME}
+)
+
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  # the following line skips the linter which checks for copyrights
+  # comment the line when a copyright and license is added to all source files
+  set(ament_cmake_copyright_FOUND TRUE)
+  # the following line skips cpplint (only works in a git repo)
+  # comment the line when this package is in a git repo and when
+  # a copyright and license is added to all source files
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/src/ros_constants/CMakeLists.txt
+++ b/src/ros_constants/CMakeLists.txt
@@ -13,6 +13,10 @@ add_library(${PROJECT_NAME}
   src/RosCanConstants.cpp
 )
 
+set_target_properties(ros_constants PROPERTIES
+  POSITION_INDEPENDENT_CODE ON
+)
+
 target_include_directories(${PROJECT_NAME} PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 	$<INSTALL_INTERFACE:include>

--- a/src/ros_constants/LICENSE
+++ b/src/ros_constants/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/ros_constants/include/ros_constants/RosCanConstants.hpp
+++ b/src/ros_constants/include/ros_constants/RosCanConstants.hpp
@@ -1,0 +1,72 @@
+#ifndef ROS_CAN_CONSTANTS_HPP
+#define ROS_CAN_CONSTANTS_HPP
+
+#include <string>
+#include "rclcpp/rclcpp.hpp"
+
+/**
+ * @brief This struct contains the names of the ROS topics used for communication with the CAN bus.
+ */
+struct RosCanConstants
+{
+	struct RosTopics
+	{
+		static const std::string can_raw_RX;			/**< Topic for all received CAN messages. */
+		static const std::string can_raw_TX;			/**< Topic for all sent CAN messages. */
+		static const std::string can_set_motor_vel;		/**< Topic used for setting the motor velocity. */
+		static const std::string can_get_motor_vel;		/**< Topic used for getting the real motor velocity. */
+		static const std::string can_get_motor_current; /**< Topic used for getting the real motor velocity. */
+		static const std::string can_stm_errors;		/**< Topic used for reporting STM32 errors. */
+		static const std::string can_stm_init;			/**< Topic used for initializing the STM32. */
+		static const std::string can_vesc_status;		/**< Topic with vesc motor status */
+		static const std::string can_manipulator_ctl;	/**< Topic used for manipulator 'manipulation' */
+		static const std::string can_sampler_status;	/**< Topic with sampler status */
+		static const std::string can_battery_info;		/**< Topic with battery (BMS & HOTSWAP) status */
+		static const std::string mqtt_rover_status;		/**< Topic for rover status from MQTT. */
+		static const std::string mqtt_sampler_control;	/**< Topic for sampler control from MQTT. */
+	};
+
+	struct VescIds
+	{
+		static const uint8_t ros_can_host; /**< ID for the computer that interconnects ROS and CAN BUS. */
+
+		// 0x50 - 0x5f - range for wheel vesc motors
+		static const uint8_t front_left_vesc;  /**< ID for the front left VESC. */
+		static const uint8_t front_right_vesc; /**< ID for the front right VESC. */
+		static const uint8_t rear_left_vesc;   /**< ID for the rear left VESC. */
+		static const uint8_t rear_right_vesc;  /**< ID for the rear right VESC. */
+
+		// 0x60 - 0x6f - range for wheel stepper motors
+		static const uint8_t front_left_stepper;  /**< ID for the front left stepper. */
+		static const uint8_t front_right_stepper; /**< ID for the front right stepper. */
+		static const uint8_t rear_left_stepper;	  /**< ID for the rear left stepper. */
+		static const uint8_t rear_right_stepper;  /**< ID for the rear right stepper. */
+
+		// 0x70 - 0x7f - range for manipulator motors
+		static const uint8_t manipulator_axis_1;  /**< ID for the manipulator base motor. */
+		static const uint8_t manipulator_axis_2;  /**< ID for the manipulator 2nd axis */
+		static const uint8_t manipulator_axis_3;  /**< ID for the manipulator 3rd axis */
+		static const uint8_t manipulator_axis_4;  /**< ID for the manipulator 4th axis */
+		static const uint8_t manipulator_axis_5;  /**< ID for the manipulator 5th axis */
+		static const uint8_t manipulator_axis_6;  /**< ID for the manipulator 6th axis */
+		static const uint8_t manipulator_gripper; /**< ID for the manipulator gripper */
+
+		// 0x80 - 0x8f - range for the sampler
+		static const uint8_t sampler_platform;		 /**< ID for the sampler platform movement */
+		static const uint8_t sampler_drill_mov;		 /**< ID for the sampler drill movement */
+		static const uint8_t sampler_drill;			 /**< ID for the sampler drill action */
+		static const uint8_t sampler_container_a;	 /**< ID for the sampler container A (position only) */
+		static const uint8_t sampler_container_b;	 /**< ID for the sampler container B (position only) */
+		static const uint8_t sampler_vacuum_suction; /**< ID for the sampler vacuum main motor -1:1 duty range */
+		static const uint8_t sampler_vacuum_a;		 /**< ID for the sampler vacuum motor A ON-OFF only (duty 0-1) */
+		static const uint8_t sampler_vacuum_b;		 /**< ID for the sampler vacuum motor B ON-OFF only (duty 0-1) */
+
+		// 0x90 - 0x9f - range for the bms
+		static const uint8_t bms_battery_left;	 /**< ID for the left battery BMS. */
+		static const uint8_t bms_battery_center; /**< ID for the center battery BMS. */
+		static const uint8_t bms_battery_right;	 /**< ID for the right battery BMS. */
+	};
+
+	static const rclcpp::Duration max_stm_sync_time; /**< Maximum time to wait for the STM32 to synchronize. */
+};
+#endif // ROS_CAN_CONSTANTS_HPP

--- a/src/ros_constants/include/ros_constants/RosCanConstants.hpp
+++ b/src/ros_constants/include/ros_constants/RosCanConstants.hpp
@@ -11,19 +11,21 @@ struct RosCanConstants
 {
 	struct RosTopics
 	{
-		static const std::string can_raw_RX;			/**< Topic for all received CAN messages. */
-		static const std::string can_raw_TX;			/**< Topic for all sent CAN messages. */
-		static const std::string can_set_motor_vel;		/**< Topic used for setting the motor velocity. */
-		static const std::string can_get_motor_vel;		/**< Topic used for getting the real motor velocity. */
-		static const std::string can_get_motor_current; /**< Topic used for getting the real motor velocity. */
-		static const std::string can_stm_errors;		/**< Topic used for reporting STM32 errors. */
-		static const std::string can_stm_init;			/**< Topic used for initializing the STM32. */
-		static const std::string can_vesc_status;		/**< Topic with vesc motor status */
-		static const std::string can_manipulator_ctl;	/**< Topic used for manipulator 'manipulation' */
-		static const std::string can_sampler_status;	/**< Topic with sampler status */
-		static const std::string can_battery_info;		/**< Topic with battery (BMS & HOTSWAP) status */
-		static const std::string mqtt_rover_status;		/**< Topic for rover status from MQTT. */
-		static const std::string mqtt_sampler_control;	/**< Topic for sampler control from MQTT. */
+		static const std::string can_raw_RX;					/**< Topic for all received CAN messages. */
+		static const std::string can_raw_TX;					/**< Topic for all sent CAN messages. */
+		static const std::string can_set_motor_vel;				/**< Topic used for setting the motor velocity. */
+		static const std::string can_get_motor_vel;				/**< Topic used for getting the real motor velocity. */
+		static const std::string can_get_motor_current;			/**< Topic used for getting the real motor velocity. */
+		static const std::string can_stm_errors;				/**< Topic used for reporting STM32 errors. */
+		static const std::string can_stm_init;					/**< Topic used for initializing the STM32. */
+		static const std::string can_vesc_status;				/**< Topic with vesc motor status */
+		static const std::string can_manipulator_ctl;			/**< Topic used for manipulator 'manipulation' */
+		static const std::string can_sampler_status;			/**< Topic with sampler status */
+		static const std::string can_battery_info;				/**< Topic with battery (BMS & HOTSWAP) status */
+		static const std::string can_calibration_motor_command; /**< Topic used for VESC commands during calibration */
+		static const std::string mqtt_rover_status;				/**< Topic for rover status from MQTT. */
+		static const std::string mqtt_sampler_control;			/**< Topic for sampler control from MQTT. */
+		static const std::string mqtt_calibrate_axis;			/**< Topic used to calibrate motors (wheels, manipulator) */
 	};
 
 	struct VescIds

--- a/src/ros_constants/package.xml
+++ b/src/ros_constants/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ros_constants</name>
+  <version>0.0.0</version>
+  <description>ROS Constants</description>
+  <maintainer email="adik07m@gmail.com">Adam Marciniak</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/ros_constants/src/RosCanConstants.cpp
+++ b/src/ros_constants/src/RosCanConstants.cpp
@@ -1,0 +1,51 @@
+#include "ros_constants/RosCanConstants.hpp"
+
+const std::string RosCanConstants::RosTopics::can_raw_RX = "/CAN/RX/raw";
+const std::string RosCanConstants::RosTopics::can_raw_TX = "/CAN/TX/raw";
+const std::string RosCanConstants::RosTopics::can_set_motor_vel = "/CAN/TX/set_motor_vel";
+const std::string RosCanConstants::RosTopics::can_get_motor_vel = "/CAN/RX/real_motor_vel";
+const std::string RosCanConstants::RosTopics::can_get_motor_current = "/CAN/RX/real_motor_curr";
+const std::string RosCanConstants::RosTopics::can_stm_errors = "/CAN/RX/stm_errors";
+const std::string RosCanConstants::RosTopics::can_stm_init = "/CAN/TX/stm_init";
+const std::string RosCanConstants::RosTopics::can_vesc_status = "/CAN/RX/vesc_status";
+const std::string RosCanConstants::RosTopics::can_manipulator_ctl = "/CAN/TX/manipulator_ctl";
+const std::string RosCanConstants::RosTopics::can_sampler_status = "/CAN/RX/sampler_status";
+const std::string RosCanConstants::RosTopics::can_battery_info = "/CAN/RX/battery_info";
+
+const std::string RosCanConstants::RosTopics::mqtt_rover_status = "/MQTT/RoverStatus";
+const std::string RosCanConstants::RosTopics::mqtt_sampler_control = "/MQTT/SamplerControl";
+
+const uint8_t RosCanConstants::VescIds::ros_can_host = 0x20; /**< ID for the computer that interconnects ROS and CAN BUS. */
+
+const uint8_t RosCanConstants::VescIds::front_left_vesc = 0x50;  /**< ID for the front left VESC. */
+const uint8_t RosCanConstants::VescIds::front_right_vesc = 0x51; /**< ID for the front right VESC. */
+const uint8_t RosCanConstants::VescIds::rear_right_vesc = 0x52;  /**< ID for the rear right VESC. */
+const uint8_t RosCanConstants::VescIds::rear_left_vesc = 0x53;   /**< ID for the rear left VESC. */
+
+const uint8_t RosCanConstants::VescIds::front_left_stepper = 0x60;  /**< ID for the front left stepper. */
+const uint8_t RosCanConstants::VescIds::front_right_stepper = 0x61; /**< ID for the front right stepper. */
+const uint8_t RosCanConstants::VescIds::rear_right_stepper = 0x62;  /**< ID for the rear right stepper. */
+const uint8_t RosCanConstants::VescIds::rear_left_stepper = 0x63;   /**< ID for the rear left stepper. */
+
+const uint8_t RosCanConstants::VescIds::manipulator_axis_1 = 0x70;  /**< ID for the manipulator base motor. */
+const uint8_t RosCanConstants::VescIds::manipulator_axis_2 = 0x71;  /**< ID for the manipulator 2nd axis */
+const uint8_t RosCanConstants::VescIds::manipulator_axis_3 = 0x72;  /**< ID for the manipulator 3rd axis */
+const uint8_t RosCanConstants::VescIds::manipulator_axis_4 = 0x73;  /**< ID for the manipulator 4th axis */
+const uint8_t RosCanConstants::VescIds::manipulator_axis_5 = 0x74;  /**< ID for the manipulator 5th axis */
+const uint8_t RosCanConstants::VescIds::manipulator_axis_6 = 0x75;  /**< ID for the manipulator 6th axis */
+const uint8_t RosCanConstants::VescIds::manipulator_gripper = 0x76; /**< ID for the manipulator gripper */
+
+const uint8_t RosCanConstants::VescIds::sampler_platform = 0x80;       /**< ID for the sampler platform movement */
+const uint8_t RosCanConstants::VescIds::sampler_drill_mov = 0x81;      /**< ID for the sampler drill movement */
+const uint8_t RosCanConstants::VescIds::sampler_drill = 0x82;          /**< ID for the sampler drill action */
+const uint8_t RosCanConstants::VescIds::sampler_container_a = 0x83;    /**< ID for the sampler container A (position only) */
+const uint8_t RosCanConstants::VescIds::sampler_container_b = 0x84;    /**< ID for the sampler container B (position only) */
+const uint8_t RosCanConstants::VescIds::sampler_vacuum_suction = 0x85; /**< ID for the sampler vacuum main motor -1:1 duty range */
+const uint8_t RosCanConstants::VescIds::sampler_vacuum_a = 0x86;       /**< ID for the sampler vacuum motor A ON-OFF only (duty 0-1) */
+const uint8_t RosCanConstants::VescIds::sampler_vacuum_b = 0x87;       /**< ID for the sampler vacuum motor B ON-OFF only (duty 0-1) */
+
+const uint8_t RosCanConstants::VescIds::bms_battery_left = 0x90;   /**< ID for the left battery BMS. */
+const uint8_t RosCanConstants::VescIds::bms_battery_center = 0x91; /**< ID for the center battery BMS. */
+const uint8_t RosCanConstants::VescIds::bms_battery_right = 0x92;  /**< ID for the right battery BMS. */
+
+const rclcpp::Duration RosCanConstants::max_stm_sync_time = rclcpp::Duration::from_seconds(0.005);

--- a/src/ros_constants/src/RosCanConstants.cpp
+++ b/src/ros_constants/src/RosCanConstants.cpp
@@ -11,9 +11,11 @@ const std::string RosCanConstants::RosTopics::can_vesc_status = "/CAN/RX/vesc_st
 const std::string RosCanConstants::RosTopics::can_manipulator_ctl = "/CAN/TX/manipulator_ctl";
 const std::string RosCanConstants::RosTopics::can_sampler_status = "/CAN/RX/sampler_status";
 const std::string RosCanConstants::RosTopics::can_battery_info = "/CAN/RX/battery_info";
+const std::string RosCanConstants::RosTopics::can_calibration_motor_command = "/CAN/TX/calibration_motor_command";
 
 const std::string RosCanConstants::RosTopics::mqtt_rover_status = "/MQTT/RoverStatus";
 const std::string RosCanConstants::RosTopics::mqtt_sampler_control = "/MQTT/SamplerControl";
+const std::string RosCanConstants::RosTopics::mqtt_calibrate_axis = "/MQTT/CalibrateAxis";
 
 const uint8_t RosCanConstants::VescIds::ros_can_host = 0x20; /**< ID for the computer that interconnects ROS and CAN BUS. */
 


### PR DESCRIPTION
# Changes
## calibration_manager
A new package responsible for receiving calibration commands from the app and sending necessary frames to the motors via `can_bridge`.

## can_bridge
Modified slightly to accept calibration commands from `calibration_manager` during ESTOP on a new, separate topic.

## ros_constants
A new library package, contains `RosCanConstants` from `can_bridge`. Note that for now `can_bridge` still uses its own `RosCanConstants`.

## rex_interfaces
Updated to include a new frame, CalibrateAxis.msg, handled by `calibration_manager`. Also updates VescMotorCommand.msg to include vesc_id and useful constants.